### PR TITLE
Add hooked blocks metadata attributes in template response

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -204,3 +204,13 @@ if ( ! function_exists( 'twentytwentyfour_pattern_categories' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_pattern_categories' );
+
+function register_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
+	if ( $anchor_block === 'core/post-content' && $position === 'after' ) {
+		$hooked_blocks[] = 'core/loginout';
+	}
+
+	return $hooked_blocks;
+}
+
+add_filter( 'hooked_block_types', 'register_hooked_block', 10, 4 );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1485,7 +1485,7 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
  *                           prepared for inserting or updating the database.
  * @return stdClass|WP_Error The updated object representing a template or template part.
  */
-function inject_ignored_hooked_blocks_metadata_attributes( $changes ) {
+function inject_ignored_hooked_blocks_metadata_attributes_for_database( $changes ) {
 	$hooked_blocks = get_hooked_blocks();
 	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
 		return $changes;
@@ -1542,4 +1542,31 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes ) {
 	$changes->post_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
 	return $changes;
+}
+
+/**
+ * Inject ignoredHookedBlocks metadata attributes into a template or template part before we return
+ * it in the REST API response.
+ *
+ * @since 6.6.0
+ * @access private
+ *
+ * @param WP_REST_Response  $response  The response object.
+ * @param WP_Block_Template $template  An object representing a template or template part
+ * 
+ * @return WP_Block_Template The updated object representing a template or template part.
+ */
+function inject_ignored_hooked_blocks_metadata_attributes_for_response( $response, $template ) {
+	$hooked_blocks = get_hooked_blocks();
+	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
+		return $template;
+	}
+
+	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
+	$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
+
+	$blocks = parse_blocks( $template->content );
+	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+
+	return $template;
 }

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -752,8 +752,12 @@ add_action( 'deleted_post', '_wp_after_delete_font_family', 10, 2 );
 add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
 add_action( 'init', '_wp_register_default_font_collections' );
 
-// Add ignoredHookedBlocks metadata attribute to the template and template part post types.
-add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes' );
-add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
+// Add ignoredHookedBlocks metadata attribute to the template and template part post types before inserting it into the database.
+add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes_for_database' );
+add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes_for_database' );
+
+// Add ignoredHookedBlocks metadata attribute to the template and template part post types before returning them in the response.
+add_filter( 'rest_prepare_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes_for_response', 10, 2 );
+add_filter( 'rest_prepare_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes_for_response', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -754,7 +754,24 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			}
 		}
 
-		return $response;
+		
+		/**
+		 * Filters the post data for a REST API response.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`, refers to the post type slug.
+		 *
+		 * Possible hook names include:
+		 *
+		 *  - `rest_prepare_wp_template`
+		 *  - `rest_prepare_wp_template_part`
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param WP_REST_Response  $response The response object.
+		 * @param WP_Block_Template $template Template object.
+		 * @param WP_REST_Request   $request Request object.
+		 */
+		return apply_filters( "rest_prepare_{$this->post_type}", $response, $template, $request );
 	}
 
 	/**


### PR DESCRIPTION
Adds hooked blocks metadata attributes to the template content when preparing the response.

Trac ticket: https://core.trac.wordpress.org/ticket/59574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
