### PR TITLE
Block Hooks API: Move hooked blocks injection logic

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1120,6 +1120,47 @@ function update_ignored_hooked_blocks_postmeta( $post ) {
 }
 
 /**
+ * Hooks into the REST API response for the core/navigation block and adds the first and last inner blocks.
+ *
+ * @since 6.6.0
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     Post object.
+ * @return WP_REST_Response The response object.
+ */
+function insert_hooked_blocks_into_rest_response( $response, $post ) {
+	if ( ! isset( $response->data['content']['raw'] ) || ! isset( $response->data['content']['rendered'] ) ) {
+		return $response;
+	}
+
+	$attributes = array();
+	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+	$content = get_comment_delimited_block_content(
+		'core/navigation',
+		$attributes,
+		$response->data['content']['raw']
+	);
+
+	$content = apply_block_hooks_to_content( $content, $post );
+
+	// Remove mock Navigation block wrapper.
+	$content = remove_serialized_parent_block( $content );
+
+	$response->data['content']['raw'] = $content;
+
+	/** This filter is documented in wp-includes/post-template.php */
+	$response->data['content']['rendered'] = apply_filters( 'the_content', $content );
+
+	return $response;
+}
+
+/**
  * Returns a function that injects the theme attribute into, and hooked blocks before, a given block.
  *
  * The returned function can be used as `$pre_callback` argument to `traverse_and_serialize_block(s)`,

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -760,4 +760,7 @@ add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_me
 // Update ignoredHookedBlocks postmeta for wp_navigation post type.
 add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
 
+// Inject hooked blocks into the wp_navigation post type REST response.
+add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
+
 unset( $filter, $action );


### PR DESCRIPTION
In a similar vein as @tjcafferkey's https://github.com/WordPress/wordpress-develop/pull/6604, this introduces a new `insert_hooked_blocks_into_rest_response` filter and adds it to the `rest_prepare_wp_navigation` hook. (Note that this branch is actually based on Tom's; the reason is that it uses at least one function that's introduced there.)

This is part of an effort to move code from the Navigation block into Core. Specifically, `insert_hooked_blocks_into_rest_response` is based on [`block_core_navigation_insert_hooked_blocks_into_rest_response`](https://github.com/WordPress/gutenberg/blob/f44dfae735398aa8e9de10b47b4d598a8ad18b90/packages/block-library/src/navigation/index.php#L1642-L1667).

**Testing instructions:**

Preparation: Make sure you're using a Block Theme to test, ideally TT4. Add the following code to your site (e.g. to your theme's `functions.php`).

```php
function register_logout_block_as_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_navigation_last_child', 10, 4 );
```

1. If there's an existing `wp_navigation` post object for you Navigation menu in your database, make sure that it doesn't have any `_wp_ignored_hooked_blocks ` post meta set. (You can check the latter via `npm run wp-env run cli wp post meta list <postId>.`) Otherwise, you'll need to delete said post meta.
2. Go to the site editor and verify that the Login/out button block is added to the Navigation menu. You will probably see _two_ copies. The reason is that the Navigation block code still keeps inserting hooked blocks on its own.
3. To avoid the latter, apply the following patch, and reload the editor. You should now see only one copy of the Login/out block added.

```diff
diff --git a/src/wp-includes/blocks/navigation.php b/src/wp-includes/blocks/navigation.php
index ba1644cf60..4a62295c09 100644
--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -1566,10 +1566,3 @@ function block_core_navigation_insert_hooked_blocks_into_rest_response( $respons
  */
 $rest_prepare_wp_navigation_core_callback = 'block_core_navigation_' . 'insert_hooked_blocks_into_rest_response';
 
-/*
- * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
- * that are not present in Gutenberg's WP 6.5 compatibility layer.
- */
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_prepare_wp_navigation', $rest_prepare_wp_navigation_core_callback ) ) {
-       add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );
-}

```

I will follow up with a Gutenberg PR to make the Navigation block's insertion of hooked blocks conditional. That other PR will have to get merged and sync'd to Core _before_ we can land this change.

Trac ticket: https://core.trac.wordpress.org/ticket/60759

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
