### PR TITLE
Template Hierarchy: Extend to include root taxonomy archives

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3871,6 +3871,7 @@ class WP_Query {
 	 * query variable. After it is set up, it will be returned.
 	 *
 	 * @since 1.5.0
+	 * @since 6.8.0 Return the queried taxonomy object for taxonomy queries if no term is specified.
 	 *
 	 * @return WP_Term|WP_Post_Type|WP_Post|WP_User|null The queried object.
 	 */
@@ -3925,6 +3926,9 @@ class WP_Query {
 				if ( $this->is_category && 'category' === $this->queried_object->taxonomy ) {
 					_make_cat_compat( $this->queried_object );
 				}
+			} else {
+				// If no term is specified, return the queried taxonomy object instead.
+				return get_taxonomy( $matched_taxonomy );
 			}
 		} elseif ( $this->is_post_type_archive ) {
 			$post_type = $this->get( 'post_type' );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1760,7 +1760,7 @@ function get_the_archive_title() {
 		$prefix = _x( 'Archives:', 'post type archive title prefix' );
 	} elseif ( is_tax() ) {
 		$queried_object = get_queried_object();
-		if ( $queried_object ) {
+		if ( $queried_object instanceof WP_Term ) {
 			$tax    = get_taxonomy( $queried_object->taxonomy );
 			$title  = single_term_title( '', false );
 			$prefix = sprintf(
@@ -1768,6 +1768,9 @@ function get_the_archive_title() {
 				_x( '%s:', 'taxonomy term archive title prefix' ),
 				$tax->labels->singular_name
 			);
+		} elseif ( $queried_object instanceof WP_Taxonomy ) {
+			$title  = $queried_object->labels->singular_name;
+			$prefix = _x( 'Archives:', 'taxonomy archive title prefix' );
 		}
 	}
 

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -344,11 +344,12 @@ function get_tag_template() {
  * @return string Full path to custom taxonomy term template file.
  */
 function get_taxonomy_template() {
-	$term = get_queried_object();
+	$term_or_tax = get_queried_object();
 
 	$templates = array();
 
-	if ( ! empty( $term->slug ) ) {
+	if ( $term_or_tax instanceof WP_Term && ! empty( $term_or_tax->slug ) ) {
+		$term     = $term_or_tax;
 		$taxonomy = $term->taxonomy;
 
 		$slug_decoded = urldecode( $term->slug );
@@ -357,6 +358,9 @@ function get_taxonomy_template() {
 		}
 
 		$templates[] = "taxonomy-$taxonomy-{$term->slug}.php";
+		$templates[] = "taxonomy-$taxonomy.php";
+	} elseif ( $term_or_tax instanceof WP_Taxonomy ) {
+		$taxonomy    = $term_or_tax->name;
 		$templates[] = "taxonomy-$taxonomy.php";
 	}
 	$templates[] = 'taxonomy.php';


### PR DESCRIPTION
WIP. Based on #7271. More details to follow.

## What

Extend the permalink structure to include a dedicated template for the root taxonomy route. 

Importantly, we'd live to eventually be able to use _one_ template to render both that root taxonomy route (`/projects`), as well as the taxonomy archives for each of the terms in that taxonomy (e.g. `/projects/film`, `/projects/tv`, etc).

Trac ticket:

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
