### PR TITLE
Re-implement safecss_filter_attr() with the CSS token processor

### DIFF
--- a/docs/safecss-filter-attr-token-processor-spec.md
+++ b/docs/safecss-filter-attr-token-processor-spec.md
@@ -155,8 +155,11 @@ any tokens are accepted inside, at any depth, subject only to:
 
 Outside url constructs, gradients, and passthrough functions, the following
 tokens are accepted: `whitespace`, `ident` (without escapes), `number`,
-`percentage`, `dimension` (without escapes), `string` (without escapes),
-`hash`, `comma`, `colon`, `[-token`, `]-token`, `)-token` (stray closing
+`percentage`, `dimension` (without escapes), `string` (without escapes, and
+closed before end of input — with newlines removed during preprocessing, an
+unclosed string reaches end of input as a regular string token rather than a
+bad-string token, so closure is checked explicitly), `hash`, `comma`, `colon`,
+`[-token`, `]-token`, `)-token` (stray closing
 parens remain accepted — a pinned quirk), and `delim-token`s other than `\`,
 `&`, and `=`. The delim `!` remains accepted, which keeps `!important`
 working.
@@ -224,7 +227,7 @@ Existing suites pass unchanged. New cases to add to `data_safecss_filter_attr`
 - `url( )` with only whitespace is rejected;
 - quoted url function form `url( "…" )` with bad protocol is rejected and is
   not rescuable by the filter;
-- bad string (unclosed quote) in a value is rejected;
+- a string left unclosed at the end of input is rejected;
 - `{` in a value is rejected;
 - comment in a value is rejected;
 - filter receives the declaration source as `$css_test_string` and can rescue

--- a/docs/safecss-filter-attr-token-processor-spec.md
+++ b/docs/safecss-filter-attr-token-processor-spec.md
@@ -1,0 +1,231 @@
+# safecss_filter_attr() Token Processor Re-implementation Specification
+
+## Purpose
+
+Re-implement `safecss_filter_attr()` in `src/wp-includes/kses.php` on top of
+`WP_CSS_Token_Processor`, replacing the current `explode( ';' )` splitting and
+regex-based validation with CSS Syntax Level 3 tokenization.
+
+The function's contract is unchanged: it receives the decoded declaration-list
+contents of an HTML `style` attribute and returns a filtered declaration list,
+needing HTML escaping before being written back into an attribute.
+
+Guiding principles, shared with the style attribute processor spec:
+
+1. follow CSS declaration-list semantics when discovering declarations;
+2. preserve authored source text of accepted declarations;
+3. validate structurally over decoded tokens, not over raw bytes;
+4. when behavior must diverge from the current implementation, diverge only
+   toward strictness, except where an existing unit test pins the looser
+   behavior.
+
+The existing PHPUnit suites are the acceptance gate and must pass unchanged:
+
+- `data_safecss_filter_attr`
+- `data_kses_style_attr_with_url`
+- `data_safecss_filter_attr_filtered`
+- `data_wp_kses_style_attr_decodes_entities_before_css_filtering`
+
+## What Is Removed
+
+- The `explode( ';', $css )` declaration splitting and its `@todo`.
+- `preg_match_all( '/url\([^)]+\)/' )` and the url-pieces regex.
+- The gradient matching regex.
+- The recursive function-stripping regex for `var|calc|min|max|minmax|clamp|repeat`.
+- The character denylist check `%[\\\(&=}]|/\*%` and the `$css_test_string`
+  munging that feeds it. Validation verdicts come from token walks instead.
+
+## What Is Preserved
+
+- `_deprecated_argument()` handling of the second parameter.
+- Preprocessing: `wp_kses_no_null( $css )` followed by removal of `\n`, `\r`,
+  and `\t` bytes. This is required byte-for-byte by existing tests (for
+  example, `url(\n'…')` must serialize as `url('…' )`). The tokenizer therefore
+  never sees those bytes.
+- The `safe_style_css` filter over the allowed property list, including the
+  `--*` custom property wildcard.
+- The url-allowed property list (`background`, `background-image`, `cursor`,
+  `filter`, `list-style`, `list-style-image`) and gradient-allowed property
+  list (`background`, `background-image`).
+- The early `return $css;` when the filtered allowed-property list is empty.
+- The `safecss_filter_attr_allow_css` filter (see below).
+- Output assembly: the trimmed authored source of each accepted declaration,
+  joined with `;`, no trailing semicolon.
+
+## Declaration Discovery
+
+A single `WP_CSS_Token_Processor` pass over the preprocessed CSS splits it into
+declarations at top-level `semicolon-token`s. Nesting depth is tracked by
+counting `function-token`/`(-token`/`[-token`/`{-token` against
+`)-token`/`]-token`/`}-token` (never below zero). Semicolons at depth greater
+than zero do not split; semicolons inside strings, urls, and comments are
+inherently part of those tokens and never seen as `semicolon-token`s.
+
+Each declaration is represented by its byte range in the preprocessed source.
+Empty or whitespace-only segments are skipped.
+
+Divergence: a declaration left unclosed at EOF (for example
+`width: calc(3em; height: 10px`) now swallows the remainder of the input, as
+CSS specifies, instead of resurrecting later segments. The whole swallowed
+declaration is then rejected by value validation.
+
+## Property Handling
+
+The property/value boundary is the first `colon-token` in the declaration
+(matching the current `explode( ':', $css_item, 2 )` since a colon cannot
+legally occur earlier). The property name is the trimmed raw source before it.
+
+- Ordinary properties: exact, case-sensitive string match against the allowed
+  list (`Text-transform` remains rejected).
+- Custom properties: raw source must match `/^--[a-zA-Z0-9-_]+$/`; casing is
+  preserved and semantic.
+- Escaped property names (`\63 olor`) do not match and are rejected, since
+  matching is on raw source.
+
+A declaration whose property is neither allowed nor a valid custom property is
+a **hard rejection**: it is dropped without consulting the
+`safecss_filter_attr_allow_css` filter, exactly as today.
+
+Declarations containing no colon at all keep today's behavior: they undergo
+value validation as a bare value (passthrough functions allowed, url and
+gradient constructs not allowed) and are kept if they validate, with the
+filter consulted.
+
+## Value Validation
+
+The declaration's value token stream (everything after the first colon) is
+walked once. Validation produces either a **hard rejection** (declaration
+dropped, filter not consulted), or a boolean verdict `$allow_css` passed
+through the `safecss_filter_attr_allow_css` filter.
+
+### URL constructs
+
+A url construct is either a `url-token` (`url(unquoted)`) or a
+`function-token` named `url` (ASCII case-insensitive) containing optional
+whitespace and exactly one `string-token` before its closing `)-token`.
+
+Every url construct, at any nesting depth and for any property, has its
+decoded value trimmed and checked:
+
+- empty value, or `wp_kses_bad_protocol()` changing the value →
+  **hard rejection** of the declaration. This closes the current nesting
+  loophole where `width: calc(url(javascript:…))` escapes protocol checking.
+- valid value → the construct is acceptable only where url constructs are
+  allowed: values of url-allowed properties and custom properties, at the top
+  level or nested inside allowed functions. A valid url construct on a
+  non-url-allowed ordinary property is a soft rejection (`$allow_css = false`),
+  preserving today's filter-overridable outcome for `color: url(…)`.
+- structurally malformed url constructs (a `bad-url-token`, or a `url(`
+  function that does not close with `)` after its string) are soft rejections.
+
+CSS escapes are permitted inside url construct values; the protocol check runs
+on the decoded value.
+
+Divergence: url constructs are recognized ASCII case-insensitively (`URL(…)`),
+as CSS specifies. The old lowercase-only regex rejected uppercase variants
+outright; they are now accepted when the protocol check passes.
+
+### Gradient functions
+
+`function-token`s named `(repeating-)?(linear|radial|conic)-gradient`
+(case-sensitive, as today) are allowed in values of gradient-allowed
+properties and custom properties. Inside a gradient, in addition to ordinary
+component tokens, one level of balanced group nesting is allowed: nested
+`function-token`s of any name or bare `(-token` groups, which must close and
+must not contain further parenthesis nesting. Url constructs inside gradients
+follow the url rules above. A gradient violating these rules, or a gradient
+function on a non-gradient property, is a soft rejection.
+
+Divergence: string tokens containing parentheses inside gradients are now
+allowed (strings are atomic tokens); the old regex rejected them.
+
+### Passthrough functions
+
+`function-token`s named exactly `var`, `calc`, `min`, `max`, `minmax`,
+`clamp`, or `repeat` (case-sensitive, as today) are allowed in any value.
+Their contents are permissive, matching today's balanced-anything stripping:
+any tokens are accepted inside, at any depth, subject only to:
+
+- the function (and every nested group) must close before the declaration
+  ends; unclosed-at-EOF constructs are soft rejections;
+- url constructs inside are still subject to the url rules above;
+- `bad-string-token` and `bad-url-token` are soft rejections.
+
+### Top-level token rules
+
+Outside url constructs, gradients, and passthrough functions, the following
+tokens are accepted: `whitespace`, `ident` (without escapes), `number`,
+`percentage`, `dimension` (without escapes), `string` (without escapes),
+`hash`, `comma`, `colon`, `[-token`, `]-token`, `)-token` (stray closing
+parens remain accepted — a pinned quirk), and `delim-token`s other than `\`,
+`&`, and `=`. The delim `!` remains accepted, which keeps `!important`
+working.
+
+The following are soft rejections: `comment` tokens, `bad-string-token`,
+`bad-url-token`, `{-token`, `}-token`, bare `(-token` groups,
+`function-token`s not covered by the allowlists above, `at-keyword-token`,
+`CDO-token`, `CDC-token`, and any ident/dimension/string token whose raw
+source contains a backslash (escapes stay rejected outside url values, so
+`margin-top: \2px` remains rejected and remains rescuable by the filter).
+
+Divergences at this layer, all toward strictness: `{`, at-keywords, CDO/CDC,
+comments nested inside formerly-stripped function spans, bad strings, and bad
+urls were previously invisible to the char check in some positions and now
+soft-reject.
+
+## The safecss_filter_attr_allow_css Filter
+
+The filter is retained. `$allow_css` is now the verdict of token-based
+validation instead of the char-check regex. The second argument,
+`$css_test_string`, becomes the declaration's trimmed authored source; the
+previous value was the declaration with allowed function spans textually
+removed, which no longer exists in this design. This is a documented change to
+the filter's second argument.
+
+Hard rejections (unknown property, invalid custom property name, empty or
+bad-protocol url values) are dropped before the filter runs, exactly matching
+today's `$found = false` paths. Everything else reaches the filter and can be
+rescued (`margin-top: \2px`, `height: expression(…)`, `color: rgb(…)`,
+`margin-bottom: 2px}` all remain rescuable).
+
+## Output
+
+Accepted declarations are emitted as their trimmed authored source bytes from
+the preprocessed input (after null/`\n\r\t` removal), joined with `;`. No
+normalization, escape decoding, or whitespace collapsing is applied to output.
+
+## Implementation Shape
+
+All logic lives in `kses.php`:
+
+- `safecss_filter_attr()` keeps its signature and orchestrates preprocessing,
+  splitting, per-declaration validation, the filter, and output assembly.
+- Private helper functions (prefixed `_safecss_`, marked `@access private`)
+  implement declaration splitting and value validation over token streams. The
+  token stream for a declaration is materialized as a small array of token
+  records (type, name/value where relevant, byte range) collected during the
+  single tokenizer pass, so the value walk does not re-tokenize.
+
+No changes to `WP_CSS_Token_Processor` are expected; if a gap is found (for
+example, needing the raw source of a token), prefer using existing getters
+(`get_token_start()`, `get_token_length()`, `get_token_value()`,
+`get_unnormalized_token()`).
+
+## Test Requirements
+
+Existing suites pass unchanged. New cases to add to `data_safecss_filter_attr`
+(and the filtered variant where noted):
+
+- semicolon inside a quoted string no longer splits the declaration;
+- semicolon inside `url()` no longer splits the declaration;
+- nested bad-protocol url is rejected: `width: calc(url(javascript:alert(1)))`;
+- nested valid url on a url-allowed property passes protocol checking;
+- unclosed function swallows following declarations (whole tail rejected);
+- `url( )` with only whitespace is rejected;
+- quoted url function form `url( "…" )` with bad protocol is rejected and is
+  not rescuable by the filter;
+- bad string (unclosed quote) in a value is rejected;
+- `{` in a value is rejected;
+- comment in a value is rejected;
+- filter receives the declaration source as `$css_test_string` and can rescue
+  soft rejections but not hard rejections.

--- a/docs/safecss-filter-attr-token-processor-spec.md
+++ b/docs/safecss-filter-attr-token-processor-spec.md
@@ -117,6 +117,17 @@ decoded value trimmed and checked:
   preserving today's filter-overridable outcome for `color: url(…)`.
 - structurally malformed url constructs (a `bad-url-token`, or a `url(`
   function that does not close with `)` after its string) are soft rejections.
+  Even so, an identifiable url payload inside the malformed construct — the
+  string argument of a malformed `url(` function, or the raw inner text of a
+  `bad-url-token` (its raw source, stripped of the leading `url(` and a
+  trailing `)` if present, then trimmed) — is still protocol-checked: an empty
+  string-argument payload, or either payload failing
+  `wp_kses_bad_protocol()`, is a **hard rejection**, escalating what would
+  otherwise be a soft, filter-rescuable outcome. This is a divergence toward
+  strictness: the old regex-based implementation hard-rejected bad-protocol
+  payloads in some of these malformed shapes and accepted or soft-rejected
+  them in others; the token-based implementation now hard-rejects
+  consistently whenever the payload is identifiable.
 
 CSS escapes are permitted inside url construct values; the protocol check runs
 on the decoded value.
@@ -231,4 +242,10 @@ Existing suites pass unchanged. New cases to add to `data_safecss_filter_attr`
 - `{` in a value is rejected;
 - comment in a value is rejected;
 - filter receives the declaration source as `$css_test_string` and can rescue
-  soft rejections but not hard rejections.
+  soft rejections but not hard rejections;
+- a malformed url function with a bad-protocol string is rejected and is not
+  rescuable by the filter;
+- a bad-url-token with a bad-protocol payload is rejected and is not
+  rescuable by the filter;
+- passthrough and gradient function names match case-sensitively (`CALC(` is
+  rejected).

--- a/docs/wp-html-style-attribute-processor-spec.md
+++ b/docs/wp-html-style-attribute-processor-spec.md
@@ -23,11 +23,14 @@ The processor's north star is:
 Creation uses:
 
 ```php
-WP_HTML_Style_Attribute_Processor::create( string $decoded_css_text ): static
+WP_HTML_Style_Attribute_Processor::create( $decoded_css_text )
 ```
 
-The constructor is private. `create()` always returns a processor instance for a
-string input.
+The constructor is private. `create()` accepts only string input and returns a
+processor instance of the called class. The implementation must remain
+compatible with WordPress' supported PHP versions, so the runtime signature may
+use PHPDoc and explicit validation instead of PHP syntax unavailable in those
+versions.
 
 Callers must not pass raw `WP_HTML_Tag_Processor::get_attribute( 'style' )`
 results directly unless they have already checked that the result is a string.
@@ -60,7 +63,7 @@ The internal declaration data consists of:
 Initial public methods:
 
 ```php
-public static function create( string $decoded_css_text ): static;
+public static function create( $decoded_css_text );
 public function next_declaration( ?string $property_name = null ): bool;
 public function get_property_name(): ?string;
 public function is_important(): ?bool;

--- a/docs/wp-html-style-attribute-processor-spec.md
+++ b/docs/wp-html-style-attribute-processor-spec.md
@@ -1,0 +1,281 @@
+# WP_HTML_Style_Attribute_Processor Specification
+
+## Purpose
+
+`WP_HTML_Style_Attribute_Processor` inspects and modifies decoded CSS text from an
+HTML `style` attribute. Its input is the declaration-list contents of the
+attribute, excluding HTML attribute syntax, entity decoding, and any surrounding
+declaration-block braces.
+
+The processor preserves the CSS declaration-list model. Duplicate declarations
+remain distinct. Invalid CSS fragments are skipped or preserved according to CSS
+parser semantics unless a requested mutation cannot be proven safe.
+
+The processor's north star is:
+
+1. preserve CSS structure;
+2. preserve user intent;
+3. preserve the semantic CSS value of any existing declaration it rewrites;
+4. make minimal edits when doing so does not compromise the first three goals.
+
+## Construction
+
+Creation uses:
+
+```php
+WP_HTML_Style_Attribute_Processor::create( string $decoded_css_text ): static
+```
+
+The constructor is private. `create()` always returns a processor instance for a
+string input.
+
+Callers must not pass raw `WP_HTML_Tag_Processor::get_attribute( 'style' )`
+results directly unless they have already checked that the result is a string.
+Missing or boolean attributes are an HTML-layer concern, not accepted CSS text.
+
+Parsing is lazy. Creating a processor does not scan the style text until cursor
+movement, mutation validation, or serialization requires it.
+
+## Declaration Model
+
+The processor models each CSS declaration as:
+
+```text
+property-name: component-value-list !important?
+```
+
+The internal declaration data consists of:
+
+- decoded property name;
+- authored property-name source when available;
+- value component list source range;
+- `!important` flag;
+- nullable source range for the parsed priority span;
+- source ranges needed for safe mutation and verification.
+
+`!important` is not part of the value, including for custom properties.
+
+## Public API
+
+Initial public methods:
+
+```php
+public static function create( string $decoded_css_text ): static;
+public function next_declaration( ?string $property_name = null ): bool;
+public function get_property_name(): ?string;
+public function is_important(): ?bool;
+public function set_value( string $value, ?bool $important = null ): bool;
+public function set_important( bool $important ): bool;
+public function remove_declaration(): bool;
+public function append_declaration( string $property_name, string $value, bool $important = false ): bool;
+public function get_updated_style(): string;
+```
+
+The first API does not expose `get_value()` or `get_raw_value()`. Raw CSS values
+are difficult for callers to use safely, and a higher-level value API needs a
+separate design.
+
+Bookmarks, seek, and rewind are out of scope. Callers that need to rescan should
+create a new processor from the updated style text.
+
+## Cursor Semantics
+
+`next_declaration()` advances a forward-only cursor over CSS declarations.
+
+All current-declaration getters return `null` when the cursor is not positioned
+on a valid declaration. This includes `is_important()`.
+
+After `remove_declaration()` succeeds, the cursor becomes invalid until
+`next_declaration()` advances it. A second removal on the same invalid cursor
+returns `false`.
+
+After `set_value()` or `set_important()` succeeds without removing the
+declaration, the cursor remains on the same logical declaration.
+
+`set_value( '' )` removes the current declaration. On success it has the same
+cursor semantics as `remove_declaration()`.
+
+`append_declaration()` does not move the cursor. If the cursor was exhausted, it
+remains invalid until a later `next_declaration()` advances to the appended
+declaration.
+
+`next_declaration()` flushes pending safe edits before advancing because
+advancement must reflect the updated declaration list.
+
+Current-position getters should reflect successful pending edits without forcing
+a full reparse where practical, following HTML API style.
+
+## Property Names
+
+All public property-name arguments are decoded/plaintext CSS property names, not
+CSS-escaped identifier source.
+
+Ordinary properties match ASCII case-insensitively. Custom properties match
+exactly because casing is semantic.
+
+`get_property_name()` exposes CSS semantics:
+
+- ordinary property names are returned lowercase;
+- custom property names preserve exact decoded casing.
+
+Edits preserve authored property-name spelling when the declaration already
+exists. Appended ordinary properties serialize lowercase because there is no
+authored spelling to preserve. Appended custom properties preserve exact casing.
+
+Appended property names must be valid plaintext CSS property names. The processor
+does not escape arbitrary strings into identifiers. Custom properties follow the
+same validity rule with the required `--` prefix.
+
+## Value Validation
+
+Mutation inputs accept CSS declaration values, not declaration-list text.
+
+The supplied value must fit safely in both of these declaration slots, depending
+on the property being changed:
+
+```css
+foo: <value>;
+--foo: <value>;
+```
+
+Validation checks structure and CSS syntax safety, not property-specific browser
+support. The processor should not maintain a browser-style matrix of supported
+properties and value grammars.
+
+Values must be complete and self-contained. Reject inputs that:
+
+- are empty after CSS whitespace trimming, except `set_value( '' )`, which
+  removes the current declaration;
+- contain top-level declaration separators such as semicolons;
+- contain a top-level `!important`, because priority is a separate argument;
+- contain bad strings or bad URLs;
+- contain unmatched delimiters or constructs that are valid only because CSS
+  closes them at EOF;
+- cannot be proven to occupy only the declaration value slot.
+
+Nested semicolons and `!important` text inside balanced blocks, functions,
+strings, or URLs are allowed when the tokenizer and parser say they are part of
+the value.
+
+## Importance
+
+`set_value( $value, null )` preserves the existing important flag.
+`set_value( $value, true )` sets it.
+`set_value( $value, false )` clears it.
+
+`append_declaration()` receives importance as a separate boolean and rejects a
+top-level `!important` in `$value`.
+
+`set_important()` changes only declaration priority.
+
+When clearing importance, the processor may remove only the parsed priority span
+when that is safe. If minimal removal is unsafe, it may normalize the current
+declaration as long as it preserves CSS structure and the existing value's
+semantics. If that cannot be proven, it returns `false`.
+
+When setting importance, the processor adds canonical ` !important` at the
+parsed value end or normalizes the declaration if necessary. It must verify that
+the updated declaration reparses as important.
+
+## Mutation Atomicity And Verification
+
+Invalid or inapplicable mutations return `false` without `_doing_it_wrong()`.
+
+Failed mutations are atomic: style text, cursor state, and previous successful
+edits are preserved.
+
+A mutation returning `true` guarantees that `get_updated_style()` includes it.
+
+Every successful mutation must preserve the expected declaration-list structure.
+`set_value()` must not let an input value merge, split, hide, or otherwise change
+declarations beyond the intended current declaration.
+
+The public contract describes guarantees, not the exact validation mechanism.
+Synthetic declarations, parser comparisons, token-level checks, and reparsing are
+implementation details.
+
+Multiple mutations to the same logical declaration collapse to the final
+intended state. Mutations to different declarations in one pass are allowed when
+each mutation can be independently verified against the updated declaration
+list.
+
+## Formatting And Normalization
+
+The processor preserves surrounding text, comments, ignored invalid fragments,
+and authored spelling when cheap and safe.
+
+Minimal edits are a lower priority than safety, correctness, preserved CSS
+structure, and semantic preservation. Any normalization required to satisfy
+those higher priorities is allowed, but normalization that rewrites an existing
+declaration value must be strict: it must serialize from parsed token/component
+data with equivalent CSS semantics. If equivalence cannot be proven, the
+mutation returns `false`.
+
+`set_value()` trims supplied values according to CSS whitespace.
+
+When possible, `set_value()` replaces the current declaration's value and
+priority portion rather than normalizing the whole declaration. Correctness wins
+over whitespace preservation.
+
+## Invalid Fragments
+
+Declaration discovery follows CSS semantics. If CSS would ignore text as a
+declaration in a style attribute declaration-list context, the processor does
+not expose it as a declaration.
+
+Ignored invalid fragments are preserved where possible. Mutations touching a
+style containing invalid chunks must verify that the declaration-list structure
+remains safe. If preservation and a requested mutation are incompatible, the
+mutation returns `false` or normalizes only the range necessary to preserve
+semantics and structure.
+
+## Append And EOF Repair
+
+`append_declaration()` may succeed even when trailing text is malformed, but only
+when the processor can preserve existing CSS semantics.
+
+When trailing declaration text is valid only because CSS closes an unclosed
+function or block at EOF, appending must materialize the missing closing
+delimiters before inserting the new declaration.
+
+Example:
+
+```css
+color: var(--x
+```
+
+Appending `background: white` should produce a structurally safe equivalent such
+as:
+
+```css
+color: var(--x); background: white;
+```
+
+EOF repair is part of a successful append and appears in `get_updated_style()`.
+Repair should insert only the specific missing delimiters discovered from parser
+or tokenizer state, plus the boundary needed before the appended declaration. If
+the processor cannot determine a precise repair, append returns `false`.
+
+EOF repair is essential for append. `set_value()` replacement values must be
+self-contained and do not receive EOF repair.
+
+## Test Requirements
+
+Tests should cover:
+
+- private construction and `create()` behavior;
+- decoded string input boundary;
+- declaration traversal, duplicate preservation, and property-name matching;
+- getter `null` behavior off-cursor;
+- absence of public raw value getter in the first API;
+- `set_value()` priority preservation, setting, clearing, and empty-value
+  removal;
+- `set_important()` setting, clearing, cursor behavior, and safe normalization;
+- rejection of unsafe values and property names with atomic failure;
+- append behavior, duplicate appends, exhausted cursor behavior, and empty-value
+  rejection;
+- EOF repair for append and failure when repair cannot be precise;
+- invalid fragments, comments, adjacent declarations, and removal ranges;
+- preservation of authored spelling where required;
+- integration with `WP_HTML_Tag_Processor::set_attribute()` after callers supply
+  decoded string input.

--- a/src/wp-includes/css-api/class-wp-css-builder.php
+++ b/src/wp-includes/css-api/class-wp-css-builder.php
@@ -1,0 +1,261 @@
+<?php
+
+abstract class WP_CSS_Builder {
+	/**
+	 * Create a CSS ident token from a plain PHP string value.
+	 *
+	 * Characters not valid in CSS identifiers are hex-escaped. This uses
+	 * the same safety escaping as {@see WP_CSS_Builder::string()} for HTML
+	 * and CSS-sensitive characters, plus escaping of whitespace and other
+	 * characters not permitted in idents.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#escaping
+	 * @see https://www.w3.org/TR/css-syntax-3/#would-start-an-identifier
+	 *
+	 * @param string $value Decoded string value to encode as a CSS ident.
+	 * @return string CSS ident token text.
+	 */
+	public static function ident( string $value ): string {
+		$value  = wp_scrub_utf8( $value );
+		$result = '';
+		$length = strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$byte = ord( $value[ $i ] );
+
+			// NULL → U+FFFD REPLACEMENT CHARACTER.
+			if ( 0x00 === $byte ) {
+				$result .= "\u{FFFD}";
+				continue;
+			}
+
+			// Non-ASCII bytes (≥ 0x80): valid in idents, pass through.
+			if ( $byte >= 0x80 ) {
+				$result .= $value[ $i ];
+				continue;
+			}
+
+			// ASCII letters and underscore: always valid in idents.
+			if (
+				( $byte >= 0x41 && $byte <= 0x5A ) || // A-Z
+				( $byte >= 0x61 && $byte <= 0x7A ) || // a-z
+				0x5F === $byte                         // _
+			) {
+				$result .= $value[ $i ];
+				continue;
+			}
+
+			// Hyphen: valid in idents, but check for hyphen-digit at start.
+			if ( 0x2D === $byte ) {
+				// Hyphen at position 0 followed by a digit at position 1: escape the digit.
+				if ( 0 === $i && $i + 1 < $length && ord( $value[ $i + 1 ] ) >= 0x30 && ord( $value[ $i + 1 ] ) <= 0x39 ) {
+					$result .= '-';
+					++$i;
+					$result .= sprintf( '\\%X ', ord( $value[ $i ] ) );
+					continue;
+				}
+				$result .= '-';
+				continue;
+			}
+
+			// Digits: valid except at position 0.
+			if ( $byte >= 0x30 && $byte <= 0x39 ) {
+				if ( 0 === $i ) {
+					$result .= sprintf( '\\%X ', $byte );
+				} else {
+					$result .= $value[ $i ];
+				}
+				continue;
+			}
+
+			// Everything else: hex-escape.
+			$result .= sprintf( '\\%X ', $byte );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Create a quoted CSS string from a plain PHP string value.
+	 *
+	 * Example:
+	 *     $value = 'CSS & a "<style>" tag\'s strings';
+	 *     $css_string = WP_CSS_Builder::string( $value );
+	 *     echo "<style>*::before { content: {$css_string}; }</style>";
+	 *
+	 * CSS strings are quoted many characters that are problematic in HTML
+	 * or may be complicated for rudimentary CSS or HTML processors to handle
+	 * are encoded using Unicode escape sequences.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#escaping
+	 */
+	public static function string( string $value ): string {
+		$value   = wp_scrub_utf8( $value );
+		$escaped = strtr(
+			$value,
+			array(
+				// Escape existing backslashes to prevent unintentional escapes in result.
+				'\\'   => '\\5C ',
+
+				// Pre-processing replaces NULLs and some newlines. Replace and escape as necessary.
+				"\0"   => "\u{FFFD}",
+
+				// Normalize and replace newlines. https://www.w3.org/TR/css-syntax-3/#input-preprocessing
+				"\r\n" => '\\A ',
+				"\r"   => '\\A ',
+				"\f"   => '\\A ',
+
+				// Newlines must be escaped in CSS strings.
+				"\n"   => '\\A ',
+
+				// Arbitrary characters for Unicode escaping:
+
+				// HTML syntax may be problematic.
+				'<'    => '\\3C ',
+				'>'    => '\\3E ',
+				'&'    => '\\26 ',
+
+				// CSS syntax may be problematic.
+				','    => '\\2C ',
+				';'    => '\\3B ',
+				'{'    => '\\7B ',
+				'}'    => '\\7D ',
+				'"'    => '\\22 ',
+				"'"    => '\\27 ',
+			)
+		);
+		return "\"{$escaped}\"";
+	}
+
+	public static function normalize_and_escape_css( string $css ): string {
+		$css       = wp_scrub_utf8( $css );
+		$processor = WP_CSS_Token_Processor::create( $css );
+		if ( null === $processor ) {
+			return '';
+		}
+
+		$normalized_css = '';
+
+		while ( $processor->next_token() ) {
+			switch ( $processor->get_token_type() ) {
+
+				// Basic punctuation:
+				case WP_CSS_Token_Processor::TOKEN_SEMICOLON:
+					$normalized_css .= ';';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_COMMA:
+					$normalized_css .= ',';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_WHITESPACE:
+					$normalized_css .= ' ';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_COLON:
+					$normalized_css .= ':';
+					break;
+
+				// Paired punctuation:
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACE:
+					$normalized_css .= '{';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE:
+					$normalized_css .= '}';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_LEFT_PAREN:
+					$normalized_css .= '(';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+					$normalized_css .= ')';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET:
+					$normalized_css .= '[';
+					break;
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET:
+					$normalized_css .= ']';
+					break;
+
+				// "@" + ident
+				case WP_CSS_Token_Processor::TOKEN_AT_KEYWORD:
+					$normalized_css .= '@' . self::ident( $processor->get_token_value() );
+					break;
+
+				// ident + "("
+				case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+					$normalized_css .= self::ident( $processor->get_token_value() ) . '(';
+					break;
+
+				/*
+				 * Hash tokens are not idents but their value can be escaped as such.
+				 *
+				 *     ‖→ "#" →─┐   ┌──────────────────────────────┐   ┌─→‖
+				 *              ├─→─┤ a-z A-Z 0-9 _ - or non-ASCII ├─→─┤
+				 *              │   └──────────────────────────────┘   │
+				 *              │   ┌──────────────────────────────┐   │
+				 *              ├─→─┤            escape            ├─→─┤
+				 *              │   └──────────────────────────────┘   │
+				 *              └──────────────────←───────────────────┘
+				 */
+				case WP_CSS_Token_Processor::TOKEN_HASH:
+					$normalized_css .= '#' . self::ident( $processor->get_token_value() );
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_DIMENSION:
+					$normalized_css .= $processor->get_token_value() . $processor->get_token_unit();
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_PERCENTAGE:
+					$normalized_css .= "%{$processor->get_token_value()}";
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_NUMBER:
+					$normalized_css .= $processor->get_token_value();
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_DELIM:
+					$normalized_css .= $processor->get_token_value();
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_IDENT:
+					$normalized_css .= self::ident( $processor->get_token_value() );
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_STRING:
+					var_dump( $processor->get_token_value() );
+					$normalized_css .= self::string( $processor->get_token_value() );
+					break;
+
+				// Keep or strip comments?
+				case WP_CSS_Token_Processor::TOKEN_COMMENT:
+					$normalized_css .= substr( $css, $processor->get_token_start(), $processor->get_token_length() );
+					break;
+
+				/**
+				 * A <bad-string-token> is an open string that reaches a newline.
+				 *
+				 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+				 *
+				 * @see https://www.w3.org/TR/css-syntax-3/#preserved-tokens
+				 * > Note: The tokens <}-token>s, <)-token>s, <]-token>, <bad-string-token>, and <bad-url-token> are always parse errors, but they are preserved in the token stream by this specification to allow other specs, such as Media Queries, to define more fine-grained error-handling than just dropping an entire declaration or block.
+				 */
+				case WP_CSS_Token_Processor::TOKEN_BAD_STRING:
+					$normalized_css .= substr( $css, $processor->get_token_start(), $processor->get_token_length() ) . "\n";
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_URL:
+				case WP_CSS_Token_Processor::TOKEN_BAD_URL:
+				case WP_CSS_Token_Processor::TOKEN_CDC:
+				case WP_CSS_Token_Processor::TOKEN_CDO:
+				default:
+					throw new Error( 'unhandled token type ' . $processor->get_token_type() . ' with value ' . var_export( $processor->get_token_value(), true ) );
+			}
+		}
+
+		return strtr(
+			$normalized_css,
+			array(
+				' '  => '␠',
+				"\t" => "␉\t",
+				"\n" => "␊\n",
+			)
+		);
+	}
+}

--- a/src/wp-includes/css-api/class-wp-css-token-processor.php
+++ b/src/wp-includes/css-api/class-wp-css-token-processor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tokenizes CSS according to the CSS Syntax Level 3 specification
+ * Tokenizes CSS according to the CSS Syntax Level 3 specification.
  *
  * This class follows the algorithm in https://www.w3.org/TR/css-syntax-3/ and
  * exposes a pull-based API so callers can stream over large stylesheets without

--- a/src/wp-includes/css-api/class-wp-css-token-processor.php
+++ b/src/wp-includes/css-api/class-wp-css-token-processor.php
@@ -1,0 +1,1863 @@
+<?php
+
+/**
+ * Tokenizes CSS according to the CSS Syntax Level 3 specification.
+ *
+ * This class follows the algorithm in https://www.w3.org/TR/css-syntax-3/ and
+ * exposes a pull-based API so callers can stream over large stylesheets without
+ * allocating every token up front. Each call to next_token() advances the cursor
+ * and fills in metadata (type, value, raw slice, byte offsets) that you can read
+ * through the getter methods.
+ *
+ * ## Design choices
+ *
+ * ### On-the-fly normalization
+ *
+ * The CSS Spec requires the following normalization step:
+ *
+ * > Replace any U+000D CARRIAGE RETURN (CR) code points, U+000C FORM FEED (FF)
+ * > code points, or pairs of U+000D CARRIAGE RETURN (CR) followed by U+000A LINE
+ * > FEED (LF) in input by a single U+000A LINE FEED (LF) code point.
+ * > Replace any U+0000 NULL or surrogate code points in input with U+FFFD REPLACEMENT
+ * > CHARACTER (�).
+ *
+ * This processor delays normalization as much as possible. That keeps the raw byte
+ * positions intact for accurate rewrites while still letting consumers ask for a
+ * normalized token when they need one.
+ *
+ * ### No EOF token
+ *
+ * The EOF token is a CSS parsing concept, not CSS tokenization concept. Therefore,
+ * this processor does not produce it.
+ *
+ * ### UTF-8 handling
+ *
+ * Only UTF-8 strings are supported. Invalid sequences are replaced with U+FFFD (�)
+ * using the maximal subpart approach described in
+ * https://www.unicode.org/versions/Unicode9.0.0/ch03.pdf, section 3.9 Best Practices
+ * for Using U+FFFD.
+ *
+ * ## Usage
+ *
+ * Basic iteration:
+ *
+ *     $css = 'width: 10px;';
+ *     $processor = WP_CSS_Token_Processor::create( $css );
+ *     while ( $processor->next_token() ) {
+ *         echo $processor->get_normalized_token();
+ *     }
+ *     // Outputs:
+ *     // width: 10px;
+ *
+ * Rewriting a URL while keeping the rest of the stylesheet intact:
+ *
+ *     $css = 'background: url(old.jpg) center / cover;';
+ *     $processor = WP_CSS_Token_Processor::create( $css );
+ *     while ( $processor->next_token() ) {
+ *         if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+ *             $processor->set_value( 'uploads/new.jpg' );
+ *         }
+ *     }
+ *     $result = $processor->get_updated_css();
+ *     // background: url(uploads/new.jpg) center / cover;
+ *
+ * Gathering diagnostics with byte offsets:
+ *
+ *     $css = "color: red;\ncolor: re\nd;";
+ *     $processor = WP_CSS_Token_Processor::create( $css );
+ *     $bad_strings = array();
+ *     while ( $processor->next_token() ) {
+ *         if ( WP_CSS_Token_Processor::TOKEN_BAD_STRING === $processor->get_token_type() ) {
+ *             $bad_strings[] = array(
+ *                 'start'  => $processor->get_token_start(),
+ *                 'length' => $processor->get_token_length(),
+ *                 'value'  => $processor->get_unnormalized_token(),
+ *             );
+ *         }
+ *     }
+ *
+ * @see https://www.w3.org/TR/css-syntax-3/#tokenization
+ */
+class WP_CSS_Token_Processor {
+	/**
+	 * Token type constants matching the CSS Syntax Level 3 specification.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#tokenization
+	 */
+	public const TOKEN_WHITESPACE = 'whitespace-token';
+	public const TOKEN_COMMENT    = 'comment';
+	public const TOKEN_STRING     = 'string-token';
+
+	/**
+	 * BAD-STRING tokens occur when a string contains an unescaped newline.
+	 *
+	 * Valid strings: "hello", 'world', "line1\Aline2" (escaped newline)
+	 * Invalid (produces bad-string): "hello
+	 *                                 world"  (literal newline breaks the string)
+	 *
+	 * The processor stops at the newline and produces a bad-string token for error recovery.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-bad-string-token
+	 */
+	public const TOKEN_BAD_STRING        = 'bad-string-token';
+	public const TOKEN_HASH              = 'hash-token';
+	public const HASH_TOKEN_ID           = 'id';
+	public const HASH_TOKEN_UNRESTRICTED = 'unrestricted';
+	public const TOKEN_DELIM             = 'delim-token';
+	public const TOKEN_NUMBER            = 'number-token';
+	public const TOKEN_PERCENTAGE        = 'percentage-token';
+	public const TOKEN_DIMENSION         = 'dimension-token';
+	public const TOKEN_AT_KEYWORD        = 'at-keyword-token';
+	public const TOKEN_COLON             = 'colon-token';
+	public const TOKEN_SEMICOLON         = 'semicolon-token';
+	public const TOKEN_COMMA             = 'comma-token';
+	public const TOKEN_LEFT_PAREN        = '(-token';
+	public const TOKEN_RIGHT_PAREN       = ')-token';
+	public const TOKEN_LEFT_BRACKET      = '[-token';
+	public const TOKEN_RIGHT_BRACKET     = ']-token';
+	public const TOKEN_LEFT_BRACE        = '{-token';
+	public const TOKEN_RIGHT_BRACE       = '}-token';
+	public const TOKEN_FUNCTION          = 'function-token';
+
+	/**
+	 * URL tokens represent unquoted URLs in url() notation.
+	 *
+	 * For example, `url(image.jpg)` is a URL token.
+	 *
+	 * Quoted URLs like `url( "https://example.com" )` are handled as a function
+	 * token, _not_ a URL token.
+	 *
+	 * Bad URL tokens are created when invalid characters are encountered in
+	 * a URL token.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-url-token
+	 */
+	public const TOKEN_URL = 'url-token';
+
+	/**
+	 * BAD-URL tokens occur when a URL contains invalid characters.
+	 *
+	 * Invalid characters: quotes ("), apostrophes ('), parentheses (()
+	 * Example invalid: url(image(.jpg) or url(image".jpg)
+	 *
+	 * When detected, the processor consumes everything up to ) or EOF.
+	 * This prevents the bad URL from breaking subsequent tokens.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-bad-url-token
+	 */
+	public const TOKEN_BAD_URL = 'bad-url-token';
+
+	/**
+	 * Identifier tokens, such as `color`, `margin-top`, `red`,
+	 * `inherit`, `--my-var`, `\x-escaped`, `über` (Unicode), etc.
+	 *
+	 * There are restrictions on the codepoints that start or are contained in
+	 * an identifier, and identifiers may contain escape sequences.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+	 */
+	public const TOKEN_IDENT = 'ident-token';
+
+	/**
+	 * CDC (Comment Delimiter Close) token: -->
+	 *
+	 * Legacy token from when CSS was embedded in HTML <style> tags
+	 * and needed to be hidden from old browsers using HTML comments:
+	 *
+	 *   <style>
+	 *   <!--
+	 *   body { color: red; }
+	 *   -->
+	 *   </style>
+	 *
+	 * Modern CSS no longer needs these, but they're preserved for compatibility.
+	 * In stylesheets, they're typically treated like whitespace.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-CDC-token
+	 */
+	public const TOKEN_CDC = 'CDC-token';
+
+	/**
+	 * CDO (Comment Delimiter Open) token: <!--
+	 *
+	 * Legacy token from when CSS was embedded in HTML <style> tags.
+	 * See TOKEN_CDC for full explanation of HTML comment compatibility.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-CDO-token
+	 */
+	public const TOKEN_CDO = 'CDO-token';
+
+	/**
+	 * @var string
+	 */
+	private $css;
+
+	/**
+	 * @var int
+	 */
+	private $length = 0;
+
+	/**
+	 * @var int
+	 */
+	private $at = 0;
+
+	/**
+	 * The type of the current token. One of the self::TOKEN_* constants.
+	 *
+	 * @var string|null
+	 * @phpstan-var self::TOKEN_*|null
+	 */
+	private $token_type = null;
+
+	/**
+	 * The type flag for the current token, if any.
+	 *
+	 * Hash tokens carry an "id" or "unrestricted" flag. Per CSS Syntax Level 3,
+	 * <number-token> and <dimension-token> have a type flag indicating whether
+	 * the number was written as an integer or a number (with decimal point or
+	 * exponent). <percentage-token> does not have a type flag.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-number
+	 *
+	 * @var string|null
+	 * @phpstan-var 'id'|'unrestricted'|'integer'|'number'|null
+	 */
+	private $token_type_flag = null;
+
+	/**
+	 * The byte offset at which the current token starts.
+	 *
+	 * Example:
+	 *
+	 * background-image: url(https://example.com/image.jpg);
+	 *                   ^ token_starts_at
+	 *
+	 * @var int|null
+	 */
+	private $token_starts_at = null;
+
+	/**
+	 * The byte length of the current token.
+	 *
+	 * Example:
+	 *
+	 * background-image: url(https://example.com/image.jpg);
+	 *                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+	 *                             token_length
+	 *
+	 * @var int|null
+	 */
+	private $token_length = null;
+
+	/**
+	 * The byte offset at which the value of the current token starts.
+	 *
+	 * It is used for STRING and URL tokens. For example:
+	 *
+	 * background-image: url(https://example.com/image.jpg);
+	 *                       ^ token_value_starts_at
+	 *
+	 * @var int|null
+	 */
+	private $token_value_starts_at = null;
+
+	/**
+	 * The byte offset at which the value of the current token starts.
+	 *
+	 * It is relevant for STRING and URL tokens. For example:
+	 *
+	 * background-image: url(https://example.com/image.jpg);
+	 *                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+	 *                             token_value_length
+	 *
+	 * @var int|null
+	 */
+	private $token_value_length = null;
+
+	/**
+	 * A cache for the decoded and normalized token value.
+	 *
+	 * - `false` indicates that the value has not been computed.
+	 * - `null` is used for token types without an associated value: whitespace,
+	 *   bad-url, comment, punctuation, etc.
+	 * - `string` is used for token types with an associated value: ident, string,
+	 *   function, url, etc.
+	 *
+	 * @var string|null|false
+	 */
+	private $token_value = false;
+
+	/**
+	 * The unit of the current token, e.g. "px", "em", "deg", etc.
+	 *
+	 * @var string|null
+	 */
+	private $token_unit = null;
+
+	/**
+	 * Lexical replacements to apply to input CSS document.
+	 *
+	 * Tracks modifications to be applied to the CSS, such as changing URL values.
+	 * Each entry is an associative array with 'start', 'length', and 'text' keys.
+	 *
+	 * @var array[]
+	 */
+	private $lexical_updates = array();
+
+	/**
+	 * Constructor for the CSS processor.
+	 *
+	 * Do not instantiate directly. Use WP_CSS_Token_Processor::create() instead.
+	 *
+	 * @param string $css         CSS source to tokenize.
+	 */
+	private function __construct( string $css ) {
+		$this->css    = $css;
+		$this->length = strlen( $css );
+	}
+
+	/**
+	 * Creates a CSS processor for the given CSS string.
+	 *
+	 * Use this method to create a CSS processor instance.
+	 *
+	 * ## Current Support
+	 *
+	 * - The only supported document encoding is `UTF-8`, which is the default value.
+	 *
+	 * @param string $css      CSS source to tokenize.
+	 * @param string $encoding Text encoding of the document; must be default of 'UTF-8'.
+	 * @return static|null The created processor if successful, otherwise null.
+	 */
+	public static function create( string $css, string $encoding = 'UTF-8' ) {
+		if ( 'UTF-8' !== $encoding ) {
+			return null;
+		}
+
+		return new static( $css );
+	}
+
+	/**
+	 * Moves to the next token in the CSS stream.
+	 *
+	 * Implements the main tokenization loop, consuming the next token from the input stream.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-token
+	 *
+	 * @return bool Whether a token was found.
+	 */
+	public function next_token(): bool {
+		$this->after_token();
+
+		// Bale out once we reach the end.
+		if ( $this->at >= $this->length ) {
+			return false;
+		}
+
+		/*
+		 * CSS comments. They are not preserved as tokens in the specification, but we
+		 * still track them.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#consume-comment
+		 */
+		if (
+			$this->at + 1 < $this->length &&
+			'/' === $this->css[ $this->at ] &&
+			'*' === $this->css[ $this->at + 1 ]
+		) {
+			$this->token_type            = self::TOKEN_COMMENT;
+			$this->token_starts_at       = $this->at;
+			$this->token_value_starts_at = $this->at;
+
+			$end                      = strpos( $this->css, '*/', $this->at + 2 );
+			$this->at                 = false !== $end ? $end + 2 : $this->length;
+			$this->token_length       = $this->at - $this->token_starts_at;
+			$this->token_value_length = $this->token_length - 4;
+			return true;
+		}
+
+		/*
+		 * Whitespace tokens.
+		 *
+		 * We consider U+000A LINE FEED, U+0009 CHARACTER TABULATION, and U+0020 SPACE bytes covered by the spec.
+		 * In addition, we also capture U+000D CARRIAGE RETURN and U+000C FORM FEED that are normally converted to
+		 * U+000A LINE FEED during the preprocessing phase.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#newline
+		 * @see https://www.w3.org/TR/css-syntax-3/#whitespace
+		 */
+		$whitespace_length = strspn( $this->css, "\t\n\f\r ", $this->at );
+		if ( $whitespace_length > 0 ) {
+			$this->token_type      = self::TOKEN_WHITESPACE;
+			$this->token_length    = $whitespace_length;
+			$this->token_starts_at = $this->at;
+			$this->at             += $whitespace_length;
+			return true;
+		}
+
+		/*
+		 * String tokens with either " or ' as delimiters.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+		 */
+		if ( '"' === $this->css[ $this->at ] || "'" === $this->css[ $this->at ] ) {
+			return $this->consume_string();
+		}
+
+		$char                  = $this->css[ $this->at ];
+		$this->token_starts_at = $this->at;
+
+		/*
+		 * U+0023 NUMBER SIGN (#)
+		 *
+		 * A hash token is created when # is followed by an ident code point or valid escape.
+		 * This is commonly used for hex colors (#fff) or ID selectors (#header).
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#consume-token
+		 */
+		if ( '#' === $char ) {
+			if ( $this->at + 1 < $this->length ) {
+				if (
+					$this->consume_ident_codepoint( $this->at + 1 ) > 0 ||
+					// The next two input code points are a valid escape.
+					$this->is_valid_escape( $this->at + 1 )
+				) {
+					// Create a <hash-token>.
+					++$this->at;
+
+					// > If the next 3 input code points would start an ident sequence,
+					// > set the <hash-token>'s type flag to "id".
+					$this->token_type_flag = $this->check_if_3_code_points_start_an_ident_sequence( $this->at )
+						? self::HASH_TOKEN_ID
+						: self::HASH_TOKEN_UNRESTRICTED;
+
+					// Consume an ident sequence, and set the <hash-token>'s value to the returned string.
+					$this->consume_ident_sequence();
+					$this->token_type   = self::TOKEN_HASH;
+					$this->token_length = $this->at - $this->token_starts_at;
+					return true;
+				}
+			}
+			// Otherwise, return a <delim-token> with its value set to the current input code point.
+			++$this->at;
+			$this->token_type   = self::TOKEN_DELIM;
+			$this->token_length = 1;
+			return true;
+		}
+
+		/*
+		 * Simple single-byte tokens
+		 *
+		 * These characters form their own tokens when encountered.
+		 * Note: ( tokens here are not function tokens - those are handled
+		 * in consume_ident_like() when ( follows an identifier.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#tokenization
+		 */
+		$simple = array(
+			'(' => self::TOKEN_LEFT_PAREN,
+			')' => self::TOKEN_RIGHT_PAREN,
+			',' => self::TOKEN_COMMA,
+			':' => self::TOKEN_COLON,
+			';' => self::TOKEN_SEMICOLON,
+			'[' => self::TOKEN_LEFT_BRACKET,
+			']' => self::TOKEN_RIGHT_BRACKET,
+			'{' => self::TOKEN_LEFT_BRACE,
+			'}' => self::TOKEN_RIGHT_BRACE,
+		);
+		if ( isset( $simple[ $char ] ) ) {
+			++$this->at;
+			$this->token_type   = $simple[ $char ];
+			$this->token_length = 1;
+			return true;
+		}
+
+		/*
+		 * U+0040 COMMERCIAL AT (@)
+		 *
+		 * An at-keyword is @ followed by an identifier, used for at-rules like
+		 * @media, @import, @keyframes, etc.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#consume-token
+		 */
+		if ( '@' === $char ) {
+			++$this->at;
+			// If the next 3 input code points after the @ would start an ident sequence,
+			// consume an ident sequence, create an <at-keyword-token> with its value set to the returned value,
+			// and return it.
+			if ( $this->check_if_3_code_points_start_an_ident_sequence( $this->at ) ) {
+				$this->consume_ident_sequence();
+				$this->token_type   = self::TOKEN_AT_KEYWORD;
+				$this->token_length = $this->at - $this->token_starts_at;
+				return true;
+			} else {
+				// Otherwise, return a <delim-token> with its value set to the current input code point.
+				$this->token_type   = self::TOKEN_DELIM;
+				$this->token_length = 1;
+				return true;
+			}
+		}
+
+		/*
+		 * Numbers start with digits, the plus sign, minus sign, and decimal point.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#starts-with-a-number
+		 */
+		if ( $this->would_next_3_code_points_start_a_number() ) {
+			return $this->consume_numeric();
+		}
+
+		/*
+		 * U+002D HYPHEN-MINUS (-)
+		 */
+		if ( '-' === $char ) {
+			// This case is covered above:
+			// > If the input stream starts with a number.
+
+			/*
+			 * If followed by another hyphen and >, this is a CDC token (-->)
+			 *
+			 * Comment Delimiter Close - legacy HTML comment syntax in CSS.
+			 *
+			 * @see https://www.w3.org/TR/css-syntax-3/#CDC-token-diagram
+			 */
+			if (
+				$this->at + 2 < $this->length &&
+				'-' === $this->css[ $this->at + 1 ] &&
+				'>' === $this->css[ $this->at + 2 ]
+			) {
+				// Consume them and return a <CDC-token>.
+				$this->at          += 3;
+				$this->token_type   = self::TOKEN_CDC;
+				$this->token_length = 3;
+				return true;
+			}
+
+			// Otherwise, if the input stream starts with an ident sequence,
+			// reconsume the current input code point, consume an ident-like
+			// token, and return it.
+			if ( $this->check_if_3_code_points_start_an_ident_sequence( $this->at ) ) {
+				return $this->consume_ident_like();
+			}
+
+			// Otherwise, return a <delim-token> with its value set to the current input code point.
+			++$this->at;
+			$this->token_type   = self::TOKEN_DELIM;
+			$this->token_length = 1;
+			return true;
+		}
+
+		/*
+		 * U+003C LESS-THAN SIGN (<)
+		 * If followed by !--, this is a CDO token (<!--)
+		 *
+		 * Comment Delimiter Open - legacy HTML comment syntax in CSS.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#CDO-token-diagram
+		 */
+		if ( '<' === $char && $this->at + 3 < $this->length &&
+			'!' === $this->css[ $this->at + 1 ] &&
+			'-' === $this->css[ $this->at + 2 ] &&
+			'-' === $this->css[ $this->at + 3 ] ) {
+			// Consume them and return a <CDO-token>.
+			$this->at          += 4;
+			$this->token_type   = self::TOKEN_CDO;
+			$this->token_length = 4;
+			return true;
+		}
+
+		/*
+		 * Ident-start code point
+		 *
+		 * If the input stream starts with an ident sequence, reconsume the current
+		 * input code point, consume an ident-like token, and return it.
+		 *
+		 * Could be an identifier, function, or url() token.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#consume-ident-like-token
+		 */
+		if ( $this->check_if_3_code_points_start_an_ident_sequence( $this->at ) ) {
+			return $this->consume_ident_like();
+		}
+
+		/*
+		 * Delim token (delimiter)
+		 *
+		 * Any code point that doesn't match above rules becomes a delim token.
+		 * Handle multi-byte UTF-8 characters properly.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#delim-token-diagram
+		 */
+		if ( ord( $char ) >= 0x80 ) {
+			$new_at         = $this->at;
+			$invalid_length = 0;
+			if ( 1 !== _wp_scan_utf8( $this->css, $new_at, $invalid_length, null, 1 ) ) {
+				/**
+				 * Trouble ahead!
+				 * Bytes at $at are not a valid UTF-8 sequence.
+				 *
+				 * We'll move forward by $invalid_length bytes and continue processing.
+				 * Later on, during the string decoding, we'll replace the invalid bytes with U+FFFD
+				 * via maximal subpart”replacement.
+				 */
+				$matched_bytes = $invalid_length;
+			} else {
+				$matched_bytes = $new_at - $this->at;
+			}
+
+			$this->at          += $matched_bytes;
+			$this->token_type   = self::TOKEN_DELIM;
+			$this->token_length = $matched_bytes;
+			return true;
+		}
+
+		// Single ASCII delim.
+		++$this->at;
+		$this->token_type   = self::TOKEN_DELIM;
+		$this->token_length = 1;
+		return true;
+	}
+
+	/**
+	 * Gets the current token type.
+	 *
+	 * @return string|null
+	 * @phpstan-return self::TOKEN_*|null
+	 */
+	public function get_token_type(): ?string {
+		return $this->token_type;
+	}
+
+	/**
+	 * Gets the current token's type flag, if it has one.
+	 *
+	 * Some token types have an additional flag:
+	 * - Hash tokens have an "id" or "unrestricted" flag.
+	 * - Number and dimension tokens have an "integer" flag when the number was
+	 *   written without a decimal point or exponent, and a "number" flag otherwise.
+	 * - Percentage tokens do not have a type flag.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-number
+	 *
+	 * @return string|null
+	 * @phpstan-return 'id'|'unrestricted'|'integer'|'number'|null
+	 */
+	public function get_token_type_flag(): ?string {
+		return $this->token_type_flag;
+	}
+
+	/**
+	 * Gets the normalized token text from the CSS source.
+	 *
+	 * Returns the token with CSS normalization and escape decoding applied:
+	 * - CSS escapes decoded (e.g., \6c → l, \2f → /, \A → newline)
+	 * - \r\n, \r, \f → \n
+	 * - \x00 → U+FFFD (�)
+	 *
+	 * This is different from get_token_value() which returns the semantic value
+	 * (e.g., for strings: content without quotes; for numbers: numeric value).
+	 *
+	 * @return string|null
+	 */
+	public function get_normalized_token(): ?string {
+		if ( null === $this->token_starts_at || null === $this->token_length ) {
+			return null;
+		}
+
+		return $this->decode_range(
+			$this->token_starts_at,
+			$this->token_length,
+			self::TOKEN_STRING === $this->token_type
+		);
+	}
+
+	/**
+	 * Gets the raw, unnormalized token text from the CSS source.
+	 *
+	 * Returns the exact bytes from the source without any normalization.
+	 * This preserves original line endings (\r\n, \r, \f) and null bytes.
+	 *
+	 * @return string|null
+	 */
+	public function get_unnormalized_token(): ?string {
+		if ( null === $this->token_starts_at || null === $this->token_length ) {
+			return null;
+		}
+		return substr( $this->css, $this->token_starts_at, $this->token_length );
+	}
+
+	/**
+	 * Gets the current token value as a normalized and decoded string. This is
+	 * a slight divergence from the CSS Syntax Level 3 spec, where all the numberic
+	 * values are parsed as numbers. This processor is only concerned with their
+	 * textual representation.
+	 *
+	 * Returns the semantic value of the token per CSS Syntax Level 3 spec:
+	 *
+	 * - For delimiters: the single code point
+	 * - For numbers/percentages: the string representation of the number
+	 * - For dimensions: the string representation of the number (use get_token_unit() for the unit)
+	 * - For identifiers/functions/hash/at-keywords: the decoded identifier string
+	 * - For strings/URLs: the decoded string value
+	 * - For other tokens: null
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#token-value
+	 * @return string|null
+	 */
+	public function get_token_value(): ?string {
+		if ( false === $this->token_value ) {
+			if ( null === $this->token_starts_at || null === $this->token_length ) {
+				return null;
+			}
+
+			switch ( $this->token_type ) {
+				case self::TOKEN_HASH:
+					// Hash value starts after the # character.
+					$this->token_value = $this->decode_range( $this->token_starts_at + 1, $this->token_length - 1 );
+					break;
+
+				case self::TOKEN_AT_KEYWORD:
+					// At-keyword value starts after the @ character.
+					$this->token_value = $this->decode_range( $this->token_starts_at + 1, $this->token_length - 1 );
+					break;
+
+				case self::TOKEN_FUNCTION:
+					// Function name is everything except the final (.
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length - 1 );
+					break;
+
+				case self::TOKEN_IDENT:
+					// Identifier is the entire token.
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length );
+					break;
+
+				case self::TOKEN_BAD_STRING:
+					$this->token_value = null;
+					break;
+
+				case self::TOKEN_STRING:
+					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
+						$this->token_value = $this->decode_range(
+							$this->token_value_starts_at,
+							$this->token_value_length,
+							true
+						);
+					} else {
+						$this->token_value = null;
+					}
+					break;
+
+				case self::TOKEN_URL:
+					// Decode and cache the URL value.
+					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
+						$this->token_value = $this->decode_range(
+							$this->token_value_starts_at,
+							$this->token_value_length
+						);
+					} else {
+						$this->token_value = null;
+					}
+					break;
+
+				case self::TOKEN_DELIM:
+					// Delim value is the single code point.
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length );
+					break;
+
+				case self::TOKEN_NUMBER:
+					// Return the string representation of the number (not parsed to float).
+					$this->token_value = substr( $this->css, $this->token_starts_at, $this->token_length );
+					break;
+
+				case self::TOKEN_PERCENTAGE:
+					// Return the string representation of the number (without the %).
+					$this->token_value = substr( $this->css, $this->token_starts_at, $this->token_length - 1 );
+					break;
+
+				case self::TOKEN_DIMENSION:
+					// Return the string representation of the number (without the unit).
+					$this->token_value = substr( $this->get_normalized_token(), 0, -strlen( $this->token_unit ) );
+					break;
+
+				default:
+					$this->token_value = null;
+					break;
+			}
+		}
+
+		return $this->token_value;
+	}
+
+	/**
+	 * Determines whether the current token is a data URI.
+	 *
+	 * Only meaningful for URL and STRING tokens. Returns false for all other token types.
+	 *
+	 * @return bool Whether the current token value starts with "data:" (case-insensitive).
+	 */
+	public function is_data_uri(): bool {
+		if ( null === $this->token_value_starts_at || null === $this->token_value_length ) {
+			return false;
+		}
+
+		if ( $this->token_value_length < 5 ) {
+			return false;
+		}
+
+		$offset = $this->token_value_starts_at;
+		return (
+			( 'd' === $this->css[ $offset ] || 'D' === $this->css[ $offset ] ) &&
+			( 'a' === $this->css[ $offset + 1 ] || 'A' === $this->css[ $offset + 1 ] ) &&
+			( 't' === $this->css[ $offset + 2 ] || 'T' === $this->css[ $offset + 2 ] ) &&
+			( 'a' === $this->css[ $offset + 3 ] || 'A' === $this->css[ $offset + 3 ] ) &&
+			':' === $this->css[ $offset + 4 ]
+		);
+	}
+
+	/**
+	 * Gets the token start at.
+	 *
+	 * @return int|null
+	 */
+	public function get_token_start(): ?int {
+		return $this->token_starts_at;
+	}
+
+	/**
+	 * Gets the token length.
+	 *
+	 * @return int|null
+	 */
+	public function get_token_length(): ?int {
+		return $this->token_length;
+	}
+
+	/**
+	 * Gets the unit for dimension tokens.
+	 *
+	 * @return string|null
+	 */
+	public function get_token_unit(): ?string {
+		return $this->token_unit;
+	}
+
+	/**
+	 * Gets the byte at where the token value starts (for STRING and URL tokens).
+	 *
+	 * @return int|null
+	 */
+	public function get_token_value_start(): ?int {
+		return $this->token_value_starts_at;
+	}
+
+	/**
+	 * Gets the byte length of the token value (for STRING and URL tokens).
+	 *
+	 * @return int|null
+	 */
+	public function get_token_value_length(): ?int {
+		return $this->token_value_length;
+	}
+
+	/**
+	 * Sets the value of the current URL token.
+	 *
+	 * This method allows modifying the URL value in url() tokens. The new value
+	 * will be properly escaped according to CSS URL syntax rules.
+	 *
+	 * Currently only URL tokens are supported. Attempting to set the value on
+	 * other token types will return false.
+	 *
+	 * Example:
+	 *
+	 *     $css = 'background: url(old.jpg);';
+	 *     $processor = WP_CSS_Token_Processor::create( $css );
+	 *     while ( $processor->next_token() ) {
+	 *         if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+	 *             $processor->set_token_value( 'new.jpg' );
+	 *         }
+	 *     }
+	 *     echo $processor->get_updated_css();
+	 *     // Outputs: background: url(new.jpg);
+	 *
+	 * @param string $new_value The new URL value (should not include url() wrapper).
+	 * @return bool Whether the value was successfully updated.
+	 */
+	public function set_token_value( string $new_value ): bool {
+		// Only URL and string tokens are currently supported.
+		switch ( $this->token_type ) {
+			case self::TOKEN_URL:
+				$this->lexical_updates[] = array(
+					'start'  => $this->token_value_starts_at,
+					'length' => $this->token_value_length,
+					'text'   => WP_CSS_Builder::string( $new_value ),
+				);
+				return true;
+			case self::TOKEN_STRING:
+				$this->lexical_updates[] = array(
+					'start'  => $this->token_starts_at,
+					'length' => $this->token_length,
+					'text'   => WP_CSS_Builder::string( $new_value ),
+				);
+				return true;
+			default:
+				_doing_it_wrong( __METHOD__, 'set_token_value() only supports URL and string tokens. Got token type: ' . $this->token_type, '1.0.0' );
+				return false;
+		}
+	}
+
+	/**
+	 * Returns the CSS with all modifications applied.
+	 *
+	 * This method applies all queued lexical updates and returns the modified CSS.
+	 * If no modifications were made, returns the original CSS.
+	 *
+	 * Example:
+	 *
+	 *     $css = 'background: url(old.jpg);';
+	 *     $processor = WP_CSS_Token_Processor::create( $css );
+	 *     while ( $processor->next_token() ) {
+	 *         if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+	 *             $processor->set_token_value( 'new.jpg' );
+	 *         }
+	 *     }
+	 *     echo $processor->get_updated_css();
+	 *     // Outputs: background: url(new.jpg);
+	 *
+	 * @return string The modified CSS.
+	 */
+	public function get_updated_css(): string {
+		if ( empty( $this->lexical_updates ) ) {
+			return $this->css;
+		}
+
+		// Sort updates by start position in ascending order.
+		usort(
+			$this->lexical_updates,
+			function ( $a, $b ) {
+				return $a['start'] - $b['start'];
+			}
+		);
+
+		// Build the output by concatenating original CSS fragments with replacements.
+		$bytes_already_copied = 0;
+		$output               = '';
+
+		foreach ( $this->lexical_updates as $update ) {
+			$output              .= substr( $this->css, $bytes_already_copied, $update['start'] - $bytes_already_copied );
+			$output              .= $update['text'];
+			$bytes_already_copied = $update['start'] + $update['length'];
+		}
+
+		// Copy remaining CSS after last update.
+		$output .= substr( $this->css, $bytes_already_copied );
+
+		return $output;
+	}
+
+	/**
+	 * Clears token state between tokens.
+	 */
+	private function after_token(): void {
+		$this->token_type            = null;
+		$this->token_type_flag       = null;
+		$this->token_starts_at       = null;
+		$this->token_length          = null;
+		$this->token_value           = false;
+		$this->token_unit            = null;
+		$this->token_value_starts_at = null;
+		$this->token_value_length    = null;
+	}
+
+	/**
+	 * Consumes a string token.
+	 *
+	 * Strings are quoted with either " or ' and can contain escape sequences.
+	 * Newlines inside strings (without escaping) make the string invalid.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+	 *
+	 * @return bool
+	 */
+	private function consume_string(): bool {
+		// Initially create a <string-token> with its value set to the empty string.
+		$this->token_starts_at = $this->at;
+		$ending_char           = $this->css[ $this->at ];
+
+		// Skip past the opening quote.
+		++$this->at;
+		$value_starts_at = $this->at;
+
+		// Characters that need special handling: the ending quote, newlines, backslashes.
+		$special_chars = "'" === $ending_char ? "'\n\f\r\\" : "\"\n\f\r\\";
+
+		while ( $this->at < $this->length ) {
+			// Consume normal characters until we hit a special character.
+			$normal_len = strcspn( $this->css, $special_chars, $this->at );
+			if ( $normal_len > 0 ) {
+				$this->at += $normal_len;
+			}
+
+			if ( $this->at >= $this->length ) {
+				break; // EOF.
+			}
+
+			$char = $this->css[ $this->at ];
+			switch ( $char ) {
+				case $ending_char:
+					// Ending quote.
+					// Return the <string-token>.
+					++$this->at;
+					$this->token_type            = self::TOKEN_STRING;
+					$this->token_length          = $this->at - $this->token_starts_at;
+					$this->token_value_starts_at = $value_starts_at;
+					$this->token_value_length    = $this->at - $value_starts_at - 1;
+					return true;
+
+				case "\n":
+				case "\f":
+				case "\r":
+					/*
+					 * Newline.
+					 *
+					 * This is a parse error. Reconsume the current input code point,
+					 * create a <bad-string-token>, and return it.
+					 *
+					 * Unescaped newlines are not allowed in strings. To include a newline,
+					 * it must be escaped as \A or the string must end and a new one begin.
+					 *
+					 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+					 */
+					$this->token_type            = self::TOKEN_BAD_STRING;
+					$this->token_length          = $this->at - $this->token_starts_at;
+					$this->token_value_starts_at = $value_starts_at;
+					$this->token_value_length    = $this->at - $value_starts_at;
+					return true;
+
+				case '\\':
+					// U+005C REVERSE SOLIDUS (\)
+					// If the next input code point is EOF, do nothing.
+					++$this->at;
+					if ( $this->at >= $this->length ) {
+						// Backslash-EOF: do nothing, just consume the backslash.
+						continue 2;
+					}
+
+					// Otherwise, if the next input code point is a newline, consume it.
+					$next = $this->css[ $this->at ];
+					if ( "\n" === $next || "\f" === $next ) {
+						++$this->at;
+						continue 2;
+					} elseif ( "\r" === $next ) {
+						++$this->at;
+						// Handle \r\n as a single newline.
+						if ( $this->at < $this->length && "\n" === $this->css[ $this->at ] ) {
+							++$this->at;
+						}
+						continue 2;
+					}
+
+					// Otherwise, (the stream starts with a valid escape) consume an escaped
+					// code point (just to advance position, don't store the result).
+					$this->decode_escape_at( $this->at, $matched_bytes );
+					$this->at += $matched_bytes;
+					continue 2;
+
+				default:
+					_doing_it_wrong( __METHOD__, 'Unexpected character in string: ' . $char, '1.0.0' );
+					break;
+			}
+		}
+
+		// EOF
+		// This is a parse error. Return the <string-token>.
+		$this->token_type            = self::TOKEN_STRING;
+		$this->token_length          = $this->at - $this->token_starts_at;
+		$this->token_value_starts_at = $value_starts_at;
+		$this->token_value_length    = $this->at - $value_starts_at;
+		return true;
+	}
+
+	/**
+	 * Consumes a numeric token (number, percentage, dimension).
+	 *
+	 * Numbers can be integers or decimals, with optional sign and exponent.
+	 * They can be followed by % (percentage) or an identifier (dimension).
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-numeric-token
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-number
+	 *
+	 * @return bool
+	 */
+	private function consume_numeric(): bool {
+		// Consume a number and let number be the result.
+		// The type flag defaults to "integer".
+		$number_type = 'integer';
+
+		// If the next input code point is U+002B PLUS SIGN (+) or U+002D HYPHEN-MINUS (-),
+		// consume it and append it to repr.
+		if ( '+' === $this->css[ $this->at ] || '-' === $this->css[ $this->at ] ) {
+			++$this->at;
+		}
+
+		// While the next input code point is a digit, consume it and append it to repr.
+		$digits = strspn( $this->css, '0123456789', $this->at );
+		if ( $digits > 0 ) {
+			$this->at += $digits;
+		}
+
+		// If the next 2 input code points are U+002E FULL STOP (.) followed by a digit, then.
+		if (
+			$this->at + 1 < $this->length &&
+			'.' === $this->css[ $this->at ] &&
+			$this->css[ $this->at + 1 ] >= '0' &&
+			$this->css[ $this->at + 1 ] <= '9'
+		) {
+			// Consume them.
+			++$this->at;
+			// Set type to "number".
+			$number_type = 'number';
+			// While the next input code point is a digit, consume it and append it to repr.
+			$digits = strspn( $this->css, '0123456789', $this->at );
+			if ( $digits > 0 ) {
+				$this->at += $digits;
+			}
+		}
+
+		// If the next 2 or 3 input code points are U+0045 LATIN CAPITAL LETTER E (E)
+		// or U+0065 LATIN SMALL LETTER E (e), optionally followed by U+002D HYPHEN-MINUS (-)
+		// or U+002B PLUS SIGN (+), followed by a digit, then.
+		if ( $this->at < $this->length ) {
+			$e = $this->css[ $this->at ];
+			if ( 'e' === $e || 'E' === $e ) {
+				$save_pos = $this->at;
+				++$this->at;
+				$has_exp = false;
+
+				if ( $this->at < $this->length ) {
+					$next = $this->css[ $this->at ];
+					if ( ( '+' === $next || '-' === $next ) && $this->at + 1 < $this->length &&
+						$this->css[ $this->at + 1 ] >= '0' && $this->css[ $this->at + 1 ] <= '9' ) {
+						// Consume them.
+						++$this->at;
+						$has_exp = true;
+					} elseif ( $next >= '0' && $next <= '9' ) {
+						$has_exp = true;
+					}
+				}
+
+				if ( $has_exp ) {
+					// Set type to "number".
+					$number_type = 'number';
+					// While the next input code point is a digit, consume it and append it to repr.
+					$digits = strspn( $this->css, '0123456789', $this->at );
+					if ( $digits > 0 ) {
+						$this->at += $digits;
+					}
+				} else {
+					$this->at = $save_pos;
+				}
+			}
+		}
+
+		/**
+		 * This is the end of spec section 4.3.12. Consume a number.
+		 * We still have some work to do as specified in section 4.3.3. Consume a numeric token:
+		 * https://www.w3.org/TR/css-syntax-3/#consume-numeric-token
+		 */
+
+		// If the next 3 input code points would start an ident sequence, then.
+		if ( $this->check_if_3_code_points_start_an_ident_sequence( $this->at ) ) {
+			// Create a <dimension-token> with the same value and type flag as number,
+			// and a unit set initially to the empty string.
+			// Consume an ident sequence. Set the <dimension-token>'s unit to the returned value.
+			$unit_starts_at = $this->at;
+			$this->consume_ident_sequence();
+			$this->token_unit      = $this->decode_range( $unit_starts_at, $this->at - $unit_starts_at );
+			$this->token_type      = self::TOKEN_DIMENSION;
+			$this->token_type_flag = $number_type;
+			$this->token_length    = $this->at - $this->token_starts_at;
+			return true;
+		}
+
+		// Otherwise, if the next input code point is U+0025 PERCENTAGE SIGN (%), consume it.
+		// Create a <percentage-token> with the same value as number, and return it.
+		// Note: percentage tokens do not have a type flag per spec.
+		if ( $this->at < $this->length && '%' === $this->css[ $this->at ] ) {
+			++$this->at;
+			$this->token_type   = self::TOKEN_PERCENTAGE;
+			$this->token_length = $this->at - $this->token_starts_at;
+			return true;
+		}
+
+		// Otherwise, create a <number-token> with the same value and type flag as number, and return it.
+		$this->token_type      = self::TOKEN_NUMBER;
+		$this->token_type_flag = $number_type;
+		$this->token_length    = $this->at - $this->token_starts_at;
+		return true;
+	}
+
+	/**
+	 * Consumes an ident-like token (function, url, ident).
+	 *
+	 * After consuming an identifier, checks if it's followed by '(' to determine
+	 * if it's a function or url() token, otherwise it's a plain identifier.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-ident-like-token
+	 *
+	 * @return bool
+	 */
+	private function consume_ident_like(): bool {
+		// Consume an ident sequence, and let string be the result.
+		$ident_start = $this->at;
+		$decoded     = $this->consume_ident_sequence();
+		$string      = $decoded ?? $this->decode_range( $ident_start, $this->at - $ident_start );
+
+		// If string's value is an ASCII case-insensitive match for "url",
+		// and the next input code point is U+0028 LEFT PARENTHESIS (().
+		if ( 0 === strcasecmp( $string, 'url' ) && $this->at < $this->length && '(' === $this->css[ $this->at ] ) {
+			// Consume it.
+			++$this->at;
+
+			// While the next two input code points are whitespace, consume the next input code point.
+			$ws_len = strspn( $this->css, "\t\n\f\r ", $this->at );
+
+			// If the next one or two input code points are U+0022 QUOTATION MARK ("),
+			// U+0027 APOSTROPHE ('), or whitespace followed by U+0022 QUOTATION MARK (")
+			// or U+0027 APOSTROPHE (').
+			if ( $this->at + $ws_len < $this->length ) {
+				$next = $this->css[ $this->at + $ws_len ];
+				if ( '"' === $next || "'" === $next ) {
+					// then create a <function-token> with its value set to string and return it.
+					if ( null !== $decoded ) {
+						$this->token_value = $decoded;
+					}
+					$this->token_type   = self::TOKEN_FUNCTION;
+					$this->token_length = $this->at - $this->token_starts_at;
+					return true;
+				}
+			}
+
+			// Otherwise, consume a url token, and return it.
+			$this->at += $ws_len;
+			return $this->consume_url();
+		}
+
+		// Otherwise, if the next input code point is U+0028 LEFT PARENTHESIS (().
+		if ( $this->at < $this->length && '(' === $this->css[ $this->at ] ) {
+			// Consume it.
+			++$this->at;
+			// Create a <function-token> with its value set to string and return it.
+			if ( null !== $decoded ) {
+				$this->token_value = $decoded;
+			}
+			$this->token_type   = self::TOKEN_FUNCTION;
+			$this->token_length = $this->at - $this->token_starts_at;
+			return true;
+		}
+
+		// Otherwise, create an <ident-token> with its value set to string and return it.
+		if ( null !== $decoded ) {
+			$this->token_value = $decoded;
+		}
+		$this->token_type   = self::TOKEN_IDENT;
+		$this->token_length = $this->at - $this->token_starts_at;
+		return true;
+	}
+
+	/**
+	 * Consumes a url token.
+	 *
+	 * URL tokens can contain unquoted URLs with escape sequences but not quotes,
+	 * parentheses, or certain control characters. Invalid characters create a
+	 * bad-url token.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-url-token
+	 *
+	 * @return bool
+	 */
+	private function consume_url(): bool {
+		// Initially create a <url-token> with its value set to the empty string.
+		// Consume as much whitespace as possible.
+		$this->at += strspn( $this->css, "\t\n\f\r ", $this->at );
+
+		$value_starts_at = $this->at;
+
+		// Repeatedly consume the next input code point from the stream.
+		while ( $this->at < $this->length ) {
+			// U+0029 RIGHT PARENTHESIS ())
+			// Return the <url-token>.
+			if ( ')' === $this->css[ $this->at ] ) {
+				++$this->at;
+				$this->token_type            = self::TOKEN_URL;
+				$this->token_length          = $this->at - $this->token_starts_at;
+				$this->token_value_starts_at = $value_starts_at;
+				$this->token_value_length    = $this->at - $value_starts_at - 1;
+				return true;
+			}
+
+			// whitespace
+			// Consume as much whitespace as possible. If the next input code point is
+			// U+0029 RIGHT PARENTHESIS ()) or EOF, consume it and return the <url-token>
+			// (if EOF was encountered, this is a parse error); otherwise, consume the
+			// remnants of a bad url, create a <bad-url-token>, and return it.
+			$ws_len = strspn( $this->css, "\t\n\f\r ", $this->at );
+			if ( $ws_len > 0 ) {
+				$value_ends_at = $this->at;
+				$this->at     += $ws_len;
+				// Accept either ) or EOF after whitespace.
+				if ( $this->at >= $this->length ) {
+					// EOF is a parse error, but we return the <url-token> anyway.
+					$this->token_type            = self::TOKEN_URL;
+					$this->token_length          = $this->at - $this->token_starts_at;
+					$this->token_value_starts_at = $value_starts_at;
+					$this->token_value_length    = $value_ends_at - $value_starts_at;
+					return true;
+				}
+
+				if ( ')' === $this->css[ $this->at ] ) {
+					// Skip the closing parenthesis and return the <url-token>.
+					++$this->at;
+					$this->token_type            = self::TOKEN_URL;
+					$this->token_length          = $this->at - $this->token_starts_at;
+					$this->token_value_starts_at = $value_starts_at;
+					$this->token_value_length    = $value_ends_at - $value_starts_at;
+					return true;
+				}
+
+				return $this->consume_remnants_of_bad_url();
+			}
+
+			// These codepoints trigger a parse error.
+			$byte = ord( $this->css[ $this->at ] );
+			if (
+				'"' === $this->css[ $this->at ] ||
+				"'" === $this->css[ $this->at ] ||
+				'(' === $this->css[ $this->at ] ||
+
+				// Non-printable code point.
+				$byte <= 0x08 ||
+
+				// Line Tabulation.
+				0x0B === $byte ||
+
+				// Control characters.
+				( $byte >= 0x000E && $byte <= 0x001F ) ||
+
+				// Delete.
+				0x7F === $byte
+			) {
+				// Consume the remnants of a bad url,
+				// create a <bad-url-token>, and return it.
+				return $this->consume_remnants_of_bad_url();
+			}
+
+			// U+005C REVERSE SOLIDUS (\)
+			// If the stream starts with a valid escape, consume an escaped code point.
+			if ( '\\' === $this->css[ $this->at ] ) {
+				if ( $this->is_valid_escape( $this->at ) ) {
+					++$this->at;
+					$this->decode_escape_at( $this->at, $matched_bytes );
+					$this->at += $matched_bytes;
+					continue;
+				}
+				// Otherwise, this is a parse error. Consume the remnants of a bad url,
+				// create a <bad-url-token>, and return it.
+				return $this->consume_remnants_of_bad_url();
+			}
+
+			$at             = $this->at;
+			$invalid_length = 0;
+			if ( 1 !== _wp_scan_utf8( $this->css, $at, $invalid_length, null, 1 ) ) {
+				/**
+				 * Trouble ahead!
+				 * Bytes at $at are not a valid UTF-8 sequence.
+				 *
+				 * We'll move forward by $invalid_length bytes and continue processing.
+				 * Later on, during the string decoding, we'll replace the invalid bytes with U+FFFD
+				 * via maximal subpart”replacement.
+				 */
+				$this->at += $invalid_length;
+			} else {
+				$this->at = $at;
+			}
+		}
+
+		// EOF
+		// This is a parse error. Return the <url-token>.
+		$this->token_type            = self::TOKEN_URL;
+		$this->token_length          = $this->at - $this->token_starts_at;
+		$this->token_value_starts_at = $value_starts_at;
+		$this->token_value_length    = $this->at - $value_starts_at;
+		return true;
+	}
+
+	/**
+	 * Finishes a bad url token by consuming remnants.
+	 *
+	 * When an invalid character is encountered in a URL, we must consume
+	 * the remainder of the URL up to the closing ) or EOF.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-remnants-of-bad-url
+	 *
+	 * @return bool
+	 */
+	private function consume_remnants_of_bad_url(): bool {
+		while ( $this->at < $this->length ) {
+			$this->at += strcspn( $this->css, ')\\', $this->at );
+
+			if ( $this->at >= $this->length ) {
+				break;
+			}
+
+			if ( '\\' === $this->css[ $this->at ] ) {
+				++$this->at;
+				if ( $this->is_valid_escape( $this->at - 1 ) ) {
+					$this->decode_escape_at( $this->at, $matched_bytes );
+					$this->at += $matched_bytes;
+					continue;
+				}
+			} elseif ( ')' === $this->css[ $this->at ] ) {
+				++$this->at;
+				break;
+			}
+		}
+
+		$this->token_type   = self::TOKEN_BAD_URL;
+		$this->token_length = $this->at - $this->token_starts_at;
+		return true;
+	}
+
+	/**
+	 * Consumes an identifier sequence.
+	 *
+	 * Identifiers can contain letters, digits, hyphens, underscores, non-ASCII
+	 * characters, and escape sequences. Null bytes are replaced with U+FFFD.
+	 *
+	 * Returns the decoded identifier string if escapes were encountered,
+	 * or null if no decoding was needed (can use raw substring).
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-name
+	 */
+	private function consume_ident_sequence() {
+		while ( $this->at < $this->length ) {
+			$codepoint_bytes = $this->consume_ident_codepoint( $this->at );
+			if ( $codepoint_bytes > 0 ) {
+				$this->at += $codepoint_bytes;
+				continue;
+			}
+
+			if ( $this->is_valid_escape( $this->at ) ) {
+				++$this->at;
+
+				$this->decode_escape_at( $this->at, $matched_bytes );
+				$this->at += $matched_bytes;
+				continue;
+			}
+
+			break;
+		}
+	}
+
+	/**
+	 * Ident-start code point
+	 *     A letter, a non-ASCII code point, or U+005F LOW LINE (_).
+	 *
+	 * Ident code point
+	 *     An ident-start code point, a digit, or U+002D HYPHEN-MINUS (-).
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#ident-start-code-point
+	 * @return int The number of bytes consumed.
+	 */
+	private function consume_ident_codepoint( $at ): int {
+		// ident code points.
+		if ( ( $this->css[ $at ] >= '0' && $this->css[ $at ] <= '9' ) ||
+			'-' === $this->css[ $at ] ) {
+			return 1;
+		}
+
+		return $this->consume_ident_start_codepoint( $at );
+	}
+
+
+	/**
+	 * Ident-start code point
+	 *     A letter, a non-ASCII code point, or U+005F LOW LINE (_).
+	 *
+	 * Ident code point
+	 *     An ident-start code point, a digit, or U+002D HYPHEN-MINUS (-).
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#ident-start-code-point
+	 * @return int The number of bytes consumed.
+	 */
+	private function consume_ident_start_codepoint( $at ): int {
+		if ( $at >= $this->length ) {
+			return 0;
+		}
+
+		// ASCII codepoints.
+		if ( ( $this->css[ $at ] >= 'A' && $this->css[ $at ] <= 'Z' ) ||
+			( $this->css[ $at ] >= 'a' && $this->css[ $at ] <= 'z' ) ||
+			'_' === $this->css[ $at ] ) {
+			return 1;
+		}
+
+		// Special case for null bytes – they are replaced with U+FFFD during preprocessing.
+		if ( "\x00" === $this->css[ $at ] ) {
+			return 1;
+		}
+
+		$new_at         = $at;
+		$invalid_length = 0;
+		if ( 1 !== _wp_scan_utf8( $this->css, $new_at, $invalid_length, null, 1 ) ) {
+			/**
+			 * Trouble ahead!
+			 * Bytes at $at are not a valid UTF-8 sequence.
+			 *
+			 * We'll move forward by $invalid_length bytes and continue processing.
+			 * Later on, during the string decoding, we'll replace the invalid bytes with U+FFFD
+			 * via maximal subpart”replacement.
+			 */
+			return $invalid_length;
+		}
+
+		$codepoint_byte_length = $new_at - $at;
+		$codepoint             = self::utf8_ord( substr( $this->css, $at, $codepoint_byte_length ) );
+		if ( null !== $codepoint && $codepoint >= 0x80 ) {
+			return $codepoint_byte_length;
+		}
+		return 0;
+	}
+
+	/**
+	 * Decodes and normalizes ident-like or string CSS values from a byte range.
+	 *
+	 * @param int  $start          Start byte offset.
+	 * @param int  $length         Length of the substring to decode.
+	 * @param bool $string_escapes Optional, default false. When true, apply additional escape
+	 *                             rules that apply only to string tokens.
+	 * @return string Decoded and normalized string.
+	 */
+	private function decode_range( int $start, int $length, bool $string_escapes = false ): string {
+		// Fast path: check if any processing is needed.
+		$slice         = wp_scrub_utf8( substr( $this->css, $start, $length ) );
+		$special_chars = "\\\r\f\x00";
+		if ( false === strpbrk( $slice, $special_chars ) ) {
+			// No special chars - return raw substring (almost zero allocations).
+			return $slice;
+		}
+
+		// Slow path: build decoded string (one allocation).
+		$decoded = '';
+		$at      = $start;
+		$end     = $start + $length;
+
+		while ( $at < $end ) {
+			// Find next special character within the token boundary.
+			$normal_len = strcspn( $this->css, $special_chars, $at, $end - $at );
+			if ( $normal_len > 0 ) {
+				$decoded .= wp_scrub_utf8( substr( $this->css, $at, $normal_len ) );
+				$at      += $normal_len;
+			}
+
+			if ( $at >= $end ) {
+				break;
+			}
+
+			$char = $this->css[ $at ];
+
+			// Handle escapes (if enabled).
+			if ( '\\' === $char ) {
+				if ( $string_escapes ) {
+					if ( $at + 1 >= $end ) {
+						// Backslash-EOF: consume the backslash and stop.
+						++$at;
+						continue;
+					}
+
+					$next = $this->css[ $at + 1 ];
+					if ( "\n" === $next || "\f" === $next ) {
+						// Backslash followed by LF or FF is a string line continuation.
+						$at += 2;
+						continue;
+					}
+
+					if ( "\r" === $next ) {
+						// Backslash followed by CR or CRLF is a string line continuation.
+						$at += 2;
+						if ( $at < $end && "\n" === $this->css[ $at ] ) {
+							++$at;
+						}
+						continue;
+					}
+				}
+
+				if ( $this->is_valid_escape( $at ) ) {
+					++$at;
+					$decoded .= $this->decode_escape_at( $at, $bytes_consumed );
+					$at      += $bytes_consumed;
+					continue;
+				}
+				// Invalid escape - consume the backslash and keep going.
+				$decoded .= '\\';
+				++$at;
+				continue;
+			}
+
+			// CSS normalization: \r\n, \r, and \f all become \n.
+			if ( "\r" === $char ) {
+				$decoded .= "\n";
+				++$at;
+				// Handle \r\n as single newline.
+				if ( $at < $end && "\n" === $this->css[ $at ] ) {
+					++$at;
+				}
+				continue;
+			}
+
+			if ( "\f" === $char ) {
+				$decoded .= "\n";
+				++$at;
+				continue;
+			}
+
+			// Null bytes become U+FFFD.
+			if ( "\x00" === $char ) {
+				$decoded .= "\u{FFFD}";
+				++$at;
+				continue;
+			}
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Decodes an escape sequence starting at the given offset without
+	 * modifying $this->at.
+	 *
+	 * Escape sequences are backslash followed by 1-6 hex digits (with optional
+	 * trailing whitespace) or any other character. Invalid code points are
+	 * replaced with U+FFFD.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point
+	 *
+	 * @param int $offset Byte offset (should point to the character after the backslash).
+	 * @param int &$bytes_consumed Output parameter: number of bytes consumed.
+	 * @return string The decoded character(s).
+	 */
+	private function decode_escape_at( int $offset, &$bytes_consumed ): string {
+		// This method assumes the U+005C REVERSE SOLIDUS (\) has already been consumed
+		// and the next input code point has already been verified to be part of a valid
+		// escape sequence.
+		$at = $offset;
+
+		// EOF.
+		if ( $at >= $this->length ) {
+			// This is a parse error. Return U+FFFD REPLACEMENT CHARACTER (�).
+			$bytes_consumed = 0;
+			return "\u{FFFD}";
+		}
+
+		// Hex digits (CSS spec allows at most 6).
+		$hex_len = strspn( $this->css, '0123456789ABCDEFabcdef', $at, 6 );
+		if ( $hex_len > 0 ) {
+			$hex = substr( $this->css, $at, $hex_len );
+			$at += $hex_len;
+
+			// If the next input code point is whitespace, consume it as well.
+			if ( $at < $this->length ) {
+				$next = $this->css[ $at ];
+				if ( "\t" === $next || "\n" === $next || "\f" === $next || ' ' === $next ) {
+					++$at;
+				} elseif ( "\r" === $next ) {
+					++$at;
+					// Handle \r\n as a single whitespace – the preprocessing phase would replace \r\n with \n.
+					if ( $at < $this->length && "\n" === $this->css[ $at ] ) {
+						++$at;
+					}
+				}
+			}
+
+			$bytes_consumed = $at - $offset;
+			$code_point     = hexdec( $hex );
+			if (
+				$code_point <= 0 ||
+				( $code_point >= 0xD800 && $code_point <= 0xDFFF ) ||
+				$code_point > 0x10FFFF
+			) {
+				return "\u{FFFD}";
+			}
+
+			// Convert the hex digits to a UTF-8 string.
+			return WP_HTML_Decoder::code_point_to_utf8_bytes( $code_point );
+		}
+
+		// Anything else.
+		// Return the current input code point.
+		// Null bytes are replaced with U+FFFD during preprocessing.
+		if ( "\x00" === $this->css[ $at ] ) {
+			$bytes_consumed = 1;
+			return "\u{FFFD}";
+		}
+
+		$new_at         = $at;
+		$invalid_length = 0;
+		if ( 1 !== _wp_scan_utf8( $this->css, $new_at, $invalid_length, null, 1 ) ) {
+			// Consume the invalid subpart and return U+FFFD.
+			$bytes_consumed = $invalid_length;
+			return "\u{FFFD}";
+		}
+
+		$bytes_consumed = $new_at - $at;
+		return substr( $this->css, $at, $bytes_consumed );
+	}
+
+	/**
+	 * Checks if current position starts a valid escape sequence.
+	 *
+	 * A valid escape is a backslash not followed by a newline or EOF.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#starts-with-a-valid-escape
+	 *
+	 * @param int $offset Byte offset.
+	 * @return bool
+	 */
+	private function is_valid_escape( int $offset ): bool {
+		// If the first code point is not U+005C REVERSE SOLIDUS (\), return false.
+		if ( $offset >= $this->length || '\\' !== $this->css[ $offset ] ) {
+			return false;
+		}
+		// Otherwise, if the second code point is a newline, return false.
+		if ( $offset + 1 >= $this->length ) {
+			// Second code point is EOF - this is a valid escape per spec (weird!)
+			// Are we sure we're interpreting the spec correctly?
+			return true;
+		}
+
+		// Otherwise, if the second code point is not a newline, return true.
+		return (
+			"\n" !== $this->css[ $offset + 1 ] &&
+
+			// Form feed is normalized to newline during preprocessing.
+			"\f" !== $this->css[ $offset + 1 ] &&
+
+			// Carriage return is normalized to newline during preprocessing.
+			"\r" !== $this->css[ $offset + 1 ]
+
+			// We don't need to check for \r\n separately here. The \r check alone covers
+			// that scenario.
+		);
+	}
+
+	/**
+	 * Checks if the next 3 code points would start a number.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#starts-with-a-number
+	 *
+	 * @return bool
+	 */
+	private function would_next_3_code_points_start_a_number(): bool {
+		if ( $this->at >= $this->length ) {
+			return false;
+		}
+
+		// Look at the first code point.
+
+		// U+002B PLUS SIGN (+) or U+002D HYPHEN-MINUS (-).
+		if ( '+' === $this->css[ $this->at ] || '-' === $this->css[ $this->at ] ) {
+			if ( $this->at + 1 >= $this->length ) {
+				return false;
+			}
+			// If the second code point is a digit, return true.
+			if ( $this->css[ $this->at + 1 ] >= '0' && $this->css[ $this->at + 1 ] <= '9' ) {
+				return true;
+			}
+			// Otherwise, the second code point must be a full stop (.) and the third code point must be a digit.
+			if ( '.' === $this->css[ $this->at + 1 ] && $this->at + 2 < $this->length ) {
+				return $this->css[ $this->at + 2 ] >= '0' && $this->css[ $this->at + 2 ] <= '9';
+			}
+
+			// Otherwise, return false.
+			return false;
+		}
+
+		// U+002E FULL STOP (.).
+		if ( '.' === $this->css[ $this->at ] ) {
+			if ( $this->at + 1 >= $this->length ) {
+				return false;
+			}
+			return $this->css[ $this->at + 1 ] >= '0' && $this->css[ $this->at + 1 ] <= '9';
+		}
+
+		// Digit.
+		if ( $this->css[ $this->at ] >= '0' && $this->css[ $this->at ] <= '9' ) {
+			return true;
+		}
+
+		// Anything else – return false.
+		return false;
+	}
+
+	/**
+	 * Checks if three code points would start an identifier sequence.
+	 *
+	 * This implements the CSS spec's "Check if three code points would start an ident sequence"
+	 * algorithm, which checks the code point at $offset and the following two code points.
+	 *
+	 * NOTE: "Three code points" means three Unicode code points, not three bytes.
+	 * Multi-byte UTF-8 sequences count as single code points.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#would-start-an-identifier
+	 *
+	 * @param int $offset Byte offset of the first code point to check.
+	 * @return bool
+	 */
+	private function check_if_3_code_points_start_an_ident_sequence( int $offset ): bool {
+		if ( $offset >= $this->length ) {
+			return false;
+		}
+
+		if ( '-' === $this->css[ $offset ] ) {
+			// If the second code point is a U+002D HYPHEN-MINUS (-), return true.
+			// e.g. --custom-property.
+			if ( $offset + 1 < $this->length && '-' === $this->css[ $offset + 1 ] ) {
+				return true;
+			}
+			// Otherwise, check if the second code point is an ident-START code point or valid escape.
+			// Note: After a hyphen, only ident-START code points are valid, NOT digits or hyphens.
+			++$offset;
+		}
+
+		return $this->consume_ident_start_codepoint( $offset ) > 0 || $this->is_valid_escape( $offset );
+	}
+
+	/**
+	 * Convert a UTF-8 byte sequence to its Unicode codepoint.
+	 *
+	 * @param  string $character  UTF-8 encoded byte sequence representing a single Unicode character.
+	 *
+	 * @return int Unicode codepoint.
+	 */
+	private static function utf8_ord( string $character ): int {
+		// Convert the byte sequence to its binary representation.
+		$bytes = unpack( 'C*', $character );
+
+		// Initialize the codepoint.
+		$codepoint = 0;
+
+		// Calculate the codepoint based on the number of bytes.
+		if ( 1 === count( $bytes ) ) {
+			$codepoint = $bytes[1];
+		} elseif ( 2 === count( $bytes ) ) {
+			$codepoint = ( ( $bytes[1] & 0x1F ) << 6 ) | ( $bytes[2] & 0x3F );
+		} elseif ( 3 === count( $bytes ) ) {
+			$codepoint = ( ( $bytes[1] & 0x0F ) << 12 ) | ( ( $bytes[2] & 0x3F ) << 6 ) | ( $bytes[3] & 0x3F );
+		} elseif ( 4 === count( $bytes ) ) {
+			$codepoint = ( ( $bytes[1] & 0x07 ) << 18 ) | ( ( $bytes[2] & 0x3F ) << 12 ) | ( ( $bytes[3] & 0x3F ) << 6 ) | ( $bytes[4] & 0x3F );
+		}
+
+		return $codepoint;
+	}
+}

--- a/src/wp-includes/css-api/class-wp-css-token-processor.php
+++ b/src/wp-includes/css-api/class-wp-css-token-processor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tokenizes CSS according to the CSS Syntax Level 3 specification.
+ * Tokenizes CSS according to the CSS Syntax Level 3 specification
  *
  * This class follows the algorithm in https://www.w3.org/TR/css-syntax-3/ and
  * exposes a pull-based API so callers can stream over large stylesheets without

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -10,10 +10,15 @@
 /**
  * Core class used to inspect and modify CSS declarations in an HTML style attribute.
  *
- * The processor operates on decoded style attribute values. Values read from
- * {@see WP_HTML_Tag_Processor::get_attribute()} can be passed directly to this
- * class, and values returned by {@see WP_HTML_Style_Attribute_Processor::get_updated_style()}
- * can be passed back to {@see WP_HTML_Tag_Processor::set_attribute()}.
+ * The processor operates on the decoded CSS text value of a style attribute:
+ * the CSS declaration-list contents of a declaration block, excluding the
+ * delimiting braces. It does not parse HTML attribute syntax, decode character
+ * references, or operate on raw HTML markup.
+ *
+ * Values read from {@see WP_HTML_Tag_Processor::get_attribute()} can be passed
+ * directly to this class, and values returned by
+ * {@see WP_HTML_Style_Attribute_Processor::get_updated_style()} can be passed
+ * back to {@see WP_HTML_Tag_Processor::set_attribute()}.
  *
  * Unlike associative-array based style helpers, this processor preserves the
  * declaration list model of CSS. Multiple declarations with the same property
@@ -51,6 +56,13 @@ class WP_HTML_Style_Attribute_Processor {
 	private $declarations = array();
 
 	/**
+	 * Whether the style attribute value has been parsed.
+	 *
+	 * @var bool
+	 */
+	private $parsed = false;
+
+	/**
 	 * Index of the current declaration, or -1 before the first declaration.
 	 *
 	 * @var int
@@ -81,7 +93,7 @@ class WP_HTML_Style_Attribute_Processor {
 	/**
 	 * Constructor.
 	 *
-	 * @param string|bool|null $style Decoded style attribute value.
+	 * @param string|bool|null $style Decoded CSS text value from a style attribute.
 	 */
 	public function __construct( $style = '' ) {
 		if ( null === $style || true === $style ) {
@@ -91,7 +103,6 @@ class WP_HTML_Style_Attribute_Processor {
 		}
 
 		$this->style = $style;
-		$this->parse();
 	}
 
 	/**
@@ -100,10 +111,12 @@ class WP_HTML_Style_Attribute_Processor {
 	 * When a property name is provided, normal CSS properties are matched
 	 * ASCII-case-insensitively while custom properties are matched exactly.
 	 *
-	 * @param string|null $property_name Optional property name to match.
+	 * @param string|null $property_name Optional declaration property name to match.
 	 * @return bool Whether a matching declaration was found.
 	 */
 	public function next_declaration( ?string $property_name = null ): bool {
+		$this->ensure_parsed();
+
 		for ( $i = $this->current_declaration + 1; $i < count( $this->declarations ); $i++ ) {
 			if (
 				null === $property_name ||
@@ -234,6 +247,8 @@ class WP_HTML_Style_Attribute_Processor {
 			return false;
 		}
 
+		$this->ensure_parsed();
+
 		$old_declaration_count = count( $this->declarations );
 		$trimmed_style         = rtrim( $this->style, self::WHITESPACE );
 		$insert_at             = strlen( $trimmed_style );
@@ -265,9 +280,9 @@ class WP_HTML_Style_Attribute_Processor {
 	}
 
 	/**
-	 * Returns the updated style attribute value.
+	 * Returns the updated decoded CSS text value for the style attribute.
 	 *
-	 * @return string Updated style attribute value.
+	 * @return string Updated decoded CSS text value for the style attribute.
 	 */
 	public function get_updated_style(): string {
 		if ( empty( $this->lexical_updates ) ) {
@@ -305,8 +320,12 @@ class WP_HTML_Style_Attribute_Processor {
 	 * Parses CSS tokens and declarations from the style attribute value.
 	 */
 	private function parse(): void {
+		$this->tokens       = array();
+		$this->declarations = array();
+
 		$processor = WP_CSS_Token_Processor::create( $this->style );
 		if ( null === $processor ) {
+			$this->parsed = true;
 			return;
 		}
 
@@ -323,6 +342,18 @@ class WP_HTML_Style_Attribute_Processor {
 		}
 
 		$this->parse_declaration_list();
+		$this->parsed = true;
+	}
+
+	/**
+	 * Lazily parses the style attribute value when declaration access needs it.
+	 */
+	private function ensure_parsed(): void {
+		if ( $this->parsed ) {
+			return;
+		}
+
+		$this->parse();
 	}
 
 	/**
@@ -733,12 +764,11 @@ class WP_HTML_Style_Attribute_Processor {
 	private function apply_lexical_updates( int $current_declaration, bool $current_declaration_removed = false ): void {
 		$this->style = $this->get_updated_style();
 
-		$this->tokens                      = array();
-		$this->declarations                = array();
 		$this->lexical_updates             = array();
 		$this->lexical_update_order        = 0;
 		$this->current_declaration         = $current_declaration;
 		$this->current_declaration_removed = $current_declaration_removed;
+		$this->parsed                      = false;
 
 		$this->parse();
 
@@ -881,6 +911,7 @@ class WP_HTML_Style_Attribute_Processor {
 		$expected_after  = $expected_start + strlen( $declaration_text );
 		$candidate_style = substr( $this->style, 0, $insert_at ) . $separator . $declaration_text . substr( $this->style, $insert_at );
 		$candidate       = new self( $candidate_style );
+		$candidate->ensure_parsed();
 
 		if ( count( $candidate->declarations ) !== $old_declaration_count + 1 ) {
 			return false;

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -58,6 +58,13 @@ class WP_HTML_Style_Attribute_Processor {
 	private $current_declaration = -1;
 
 	/**
+	 * Whether the current declaration was removed and no new declaration has been selected.
+	 *
+	 * @var bool
+	 */
+	private $current_declaration_removed = false;
+
+	/**
 	 * Lexical updates to apply to the original style attribute value.
 	 *
 	 * @var array<int, array{start:int, length:int, text:string, declaration:int|null, order:int}>
@@ -102,12 +109,14 @@ class WP_HTML_Style_Attribute_Processor {
 				null === $property_name ||
 				$this->matches_property_name( $this->declarations[ $i ]['name'], $property_name )
 			) {
-				$this->current_declaration = $i;
+				$this->current_declaration         = $i;
+				$this->current_declaration_removed = false;
 				return true;
 			}
 		}
 
-		$this->current_declaration = count( $this->declarations );
+		$this->current_declaration         = count( $this->declarations );
+		$this->current_declaration_removed = false;
 		return false;
 	}
 
@@ -174,6 +183,8 @@ class WP_HTML_Style_Attribute_Processor {
 			$this->current_declaration
 		);
 
+		$this->apply_lexical_updates( $this->current_declaration );
+
 		return true;
 	}
 
@@ -206,6 +217,8 @@ class WP_HTML_Style_Attribute_Processor {
 			$this->current_declaration
 		);
 
+		$this->apply_lexical_updates( $this->current_declaration - 1, true );
+
 		return true;
 	}
 
@@ -225,9 +238,10 @@ class WP_HTML_Style_Attribute_Processor {
 			return false;
 		}
 
-		$trimmed_style = rtrim( $this->style, self::WHITESPACE );
-		$insert_at     = strlen( $trimmed_style );
-		$separator     = $this->has_queued_append_at( $insert_at ) ? ' ' : '';
+		$old_declaration_count = count( $this->declarations );
+		$trimmed_style         = rtrim( $this->style, self::WHITESPACE );
+		$insert_at             = strlen( $trimmed_style );
+		$separator             = $this->has_queued_append_at( $insert_at ) ? ' ' : '';
 
 		if ( '' === $separator && '' !== trim( $trimmed_style, self::WHITESPACE ) ) {
 			$separator = ( ';' === substr( $trimmed_style, -1 ) ) ? ' ' : '; ';
@@ -238,6 +252,16 @@ class WP_HTML_Style_Attribute_Processor {
 			0,
 			$separator . $this->serialize_declaration( $property_name, $value, $important ),
 			null
+		);
+
+		$append_after_exhausted_cursor = $this->current_declaration >= $old_declaration_count;
+		$current_after_append          = $append_after_exhausted_cursor
+			? $old_declaration_count - 1
+			: $this->current_declaration;
+
+		$this->apply_lexical_updates(
+			$current_after_append,
+			$this->current_declaration_removed || $append_after_exhausted_cursor
 		);
 
 		return true;
@@ -662,11 +686,38 @@ class WP_HTML_Style_Attribute_Processor {
 	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}|null
 	 */
 	private function get_current_declaration(): ?array {
-		if ( $this->current_declaration < 0 || ! isset( $this->declarations[ $this->current_declaration ] ) ) {
+		if (
+			$this->current_declaration_removed ||
+			$this->current_declaration < 0 ||
+			! isset( $this->declarations[ $this->current_declaration ] )
+		) {
 			return null;
 		}
 
 		return $this->declarations[ $this->current_declaration ];
+	}
+
+	/**
+	 * Applies queued lexical updates and reparses the updated style attribute value.
+	 *
+	 * @param int  $current_declaration         Declaration index to keep before the next cursor advance.
+	 * @param bool $current_declaration_removed Optional. Whether the current declaration was removed.
+	 */
+	private function apply_lexical_updates( int $current_declaration, bool $current_declaration_removed = false ): void {
+		$this->style = $this->get_updated_style();
+
+		$this->tokens                      = array();
+		$this->declarations                = array();
+		$this->lexical_updates             = array();
+		$this->lexical_update_order        = 0;
+		$this->current_declaration         = $current_declaration;
+		$this->current_declaration_removed = $current_declaration_removed;
+
+		$this->parse();
+
+		if ( $this->current_declaration >= count( $this->declarations ) ) {
+			$this->current_declaration = count( $this->declarations );
+		}
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -241,16 +241,17 @@ class WP_HTML_Style_Attribute_Processor {
 		$old_declaration_count = count( $this->declarations );
 		$trimmed_style         = rtrim( $this->style, self::WHITESPACE );
 		$insert_at             = strlen( $trimmed_style );
-		$separator             = $this->has_queued_append_at( $insert_at ) ? ' ' : '';
+		$separator             = $this->get_append_separator( $insert_at );
+		$declaration_text      = $this->serialize_declaration( $property_name, $value, $important );
 
-		if ( '' === $separator && '' !== trim( $trimmed_style, self::WHITESPACE ) ) {
-			$separator = ( ';' === substr( $trimmed_style, -1 ) ) ? ' ' : '; ';
+		if ( ! $this->is_parseable_append( $insert_at, $separator, $declaration_text, $old_declaration_count ) ) {
+			return false;
 		}
 
 		$this->queue_lexical_update(
 			$insert_at,
 			0,
-			$separator . $this->serialize_declaration( $property_name, $value, $important ),
+			$separator . $declaration_text,
 			null
 		);
 
@@ -755,6 +756,112 @@ class WP_HTML_Style_Attribute_Processor {
 	private function has_queued_append_at( int $insert_at ): bool {
 		foreach ( $this->lexical_updates as $update ) {
 			if ( null === $update['declaration'] && $insert_at === $update['start'] && 0 === $update['length'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets the separator to use before an appended declaration.
+	 *
+	 * Comments and whitespace are CSS parser trivia. They do not determine
+	 * whether the existing declaration list needs a semicolon before appending.
+	 *
+	 * @param int $insert_at Byte offset at which the declaration will be inserted.
+	 * @return string Separator text.
+	 */
+	private function get_append_separator( int $insert_at ): string {
+		if ( $this->has_queued_append_at( $insert_at ) ) {
+			return ' ';
+		}
+
+		$last_token = $this->get_last_top_level_non_ignored_token_before( $insert_at );
+
+		if ( null === $last_token ) {
+			return $insert_at > 0 ? ' ' : '';
+		}
+
+		return WP_CSS_Token_Processor::TOKEN_SEMICOLON === $last_token['type'] ? ' ' : '; ';
+	}
+
+	/**
+	 * Gets the last top-level non-ignored token before a byte offset.
+	 *
+	 * @param int $insert_at Byte offset before which to scan.
+	 * @return array{type:string, value:string|null, start:int, length:int, end:int}|null Token metadata.
+	 */
+	private function get_last_top_level_non_ignored_token_before( int $insert_at ): ?array {
+		$count      = count( $this->tokens );
+		$index      = 0;
+		$last_token = null;
+
+		while ( $index < $count ) {
+			$token = $this->tokens[ $index ];
+
+			if ( $token['start'] >= $insert_at ) {
+				break;
+			}
+
+			if ( $this->is_ignored_token( $token ) ) {
+				++$index;
+				continue;
+			}
+
+			$last_token = $token;
+
+			if ( WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE );
+				continue;
+			}
+
+			++$index;
+		}
+
+		return $last_token;
+	}
+
+	/**
+	 * Checks whether an appended declaration will parse as a new declaration.
+	 *
+	 * Malformed existing declarations can leave the append point inside an
+	 * unclosed component value. In that case preserving the original text and
+	 * appending a top-level declaration are incompatible.
+	 *
+	 * @param int    $insert_at             Byte offset at which the declaration will be inserted.
+	 * @param string $separator             Separator text.
+	 * @param string $declaration_text      Serialized declaration text.
+	 * @param int    $old_declaration_count Number of declarations before appending.
+	 * @return bool Whether the appended declaration is parseable.
+	 */
+	private function is_parseable_append( int $insert_at, string $separator, string $declaration_text, int $old_declaration_count ): bool {
+		$expected_start  = $insert_at + strlen( $separator );
+		$expected_after  = $expected_start + strlen( $declaration_text );
+		$candidate_style = substr( $this->style, 0, $insert_at ) . $separator . $declaration_text . substr( $this->style, $insert_at );
+		$candidate       = new self( $candidate_style );
+
+		if ( count( $candidate->declarations ) !== $old_declaration_count + 1 ) {
+			return false;
+		}
+
+		foreach ( $candidate->declarations as $declaration ) {
+			if ( $expected_start === $declaration['start'] && $expected_after === $declaration['after'] ) {
 				return true;
 			}
 		}

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -1,0 +1,938 @@
+<?php
+/**
+ * HTML API: WP_HTML_Style_Attribute_Processor class
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ * @since {WP_VERSION}
+ */
+
+/**
+ * Core class used to inspect and modify CSS declarations in an HTML style attribute.
+ *
+ * The processor operates on decoded style attribute values. Values read from
+ * {@see WP_HTML_Tag_Processor::get_attribute()} can be passed directly to this
+ * class, and values returned by {@see WP_HTML_Style_Attribute_Processor::get_updated_style()}
+ * can be passed back to {@see WP_HTML_Tag_Processor::set_attribute()}.
+ *
+ * Unlike associative-array based style helpers, this processor preserves the
+ * declaration list model of CSS. Multiple declarations with the same property
+ * name remain separate entries and can be inspected or changed individually.
+ *
+ * @since {WP_VERSION}
+ */
+class WP_HTML_Style_Attribute_Processor {
+	/**
+	 * CSS whitespace characters.
+	 *
+	 * @var string
+	 */
+	const WHITESPACE = " \t\n\r\f";
+
+	/**
+	 * Decoded style attribute value.
+	 *
+	 * @var string
+	 */
+	private $style;
+
+	/**
+	 * CSS token metadata.
+	 *
+	 * @var array<int, array{type:string, value:string|null, start:int, length:int, end:int}>
+	 */
+	private $tokens = array();
+
+	/**
+	 * Parsed declarations.
+	 *
+	 * @var array<int, array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}>
+	 */
+	private $declarations = array();
+
+	/**
+	 * Index of the current declaration, or -1 before the first declaration.
+	 *
+	 * @var int
+	 */
+	private $current_declaration = -1;
+
+	/**
+	 * Lexical updates to apply to the original style attribute value.
+	 *
+	 * @var array<int, array{start:int, length:int, text:string, declaration:int|null, order:int}>
+	 */
+	private $lexical_updates = array();
+
+	/**
+	 * Sequence counter used to keep lexical updates in queue order.
+	 *
+	 * @var int
+	 */
+	private $lexical_update_order = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $style Decoded style attribute value.
+	 */
+	public function __construct( string $style ) {
+		$this->style = $style;
+		$this->parse();
+	}
+
+	/**
+	 * Moves to the next declaration in the style attribute value.
+	 *
+	 * When a property name is provided, normal CSS properties are matched
+	 * ASCII-case-insensitively while custom properties are matched exactly.
+	 *
+	 * @param string|null $property_name Optional property name to match.
+	 * @return bool Whether a matching declaration was found.
+	 */
+	public function next_declaration( ?string $property_name = null ): bool {
+		for ( $i = $this->current_declaration + 1; $i < count( $this->declarations ); $i++ ) {
+			if (
+				null === $property_name ||
+				$this->matches_property_name( $this->declarations[ $i ]['name'], $property_name )
+			) {
+				$this->current_declaration = $i;
+				return true;
+			}
+		}
+
+		$this->current_declaration = count( $this->declarations );
+		return false;
+	}
+
+	/**
+	 * Gets the current declaration's property name.
+	 *
+	 * @return string|null Property name, or null when not on a declaration.
+	 */
+	public function get_property_name(): ?string {
+		$declaration = $this->get_current_declaration();
+		return null === $declaration ? null : $declaration['name'];
+	}
+
+	/**
+	 * Gets the current declaration's CSS value.
+	 *
+	 * The returned value does not include a trailing !important priority.
+	 *
+	 * @return string|null CSS value, or null when not on a declaration.
+	 */
+	public function get_value(): ?string {
+		$declaration = $this->get_current_declaration();
+		if ( null === $declaration ) {
+			return null;
+		}
+
+		return trim(
+			substr( $this->style, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
+			self::WHITESPACE
+		);
+	}
+
+	/**
+	 * Indicates whether the current declaration has an !important priority.
+	 *
+	 * @return bool Whether the current declaration has an !important priority.
+	 */
+	public function is_important(): bool {
+		$declaration = $this->get_current_declaration();
+		return null !== $declaration && $declaration['important'];
+	}
+
+	/**
+	 * Sets the value of the current declaration.
+	 *
+	 * @param string    $value     CSS declaration value, without the property name.
+	 * @param bool|null $important Optional. Whether the declaration should be important.
+	 *                             Defaults to preserving the current priority.
+	 * @return bool Whether the current declaration was updated.
+	 */
+	public function set_value( string $value, ?bool $important = null ): bool {
+		$declaration = $this->get_current_declaration();
+		if ( null === $declaration || ! $this->is_valid_declaration_value( $value ) ) {
+			return false;
+		}
+
+		$is_important = null === $important ? $declaration['important'] : $important;
+		$text         = $this->serialize_declaration( $declaration['raw_name'], $value, $is_important );
+
+		$this->queue_lexical_update(
+			$declaration['start'],
+			$declaration['after'] - $declaration['start'],
+			$text,
+			$this->current_declaration
+		);
+
+		return true;
+	}
+
+	/**
+	 * Removes the current declaration from the style attribute value.
+	 *
+	 * Only the current declaration is removed. Other declarations with the same
+	 * property name remain in place.
+	 *
+	 * @return bool Whether the current declaration was removed.
+	 */
+	public function remove_declaration(): bool {
+		$declaration = $this->get_current_declaration();
+		if ( null === $declaration ) {
+			return false;
+		}
+
+		if ( '' === trim( substr( $this->style, 0, $declaration['leading_start'] ), self::WHITESPACE ) ) {
+			$remove_start = $declaration['leading_start'];
+			$remove_end   = $declaration['trailing_end'];
+		} else {
+			$remove_start = $declaration['leading_start'];
+			$remove_end   = $declaration['after'];
+		}
+
+		$this->queue_lexical_update(
+			$remove_start,
+			$remove_end - $remove_start,
+			'',
+			$this->current_declaration
+		);
+
+		return true;
+	}
+
+	/**
+	 * Appends a declaration to the style attribute value.
+	 *
+	 * Appending does not remove or replace existing declarations with the same
+	 * property name.
+	 *
+	 * @param string $property_name CSS property name.
+	 * @param string $value         CSS declaration value, without the property name.
+	 * @param bool   $important     Optional. Whether the declaration should be important. Default false.
+	 * @return bool Whether the declaration was appended.
+	 */
+	public function append_declaration( string $property_name, string $value, bool $important = false ): bool {
+		if ( ! $this->is_valid_property_name( $property_name ) || ! $this->is_valid_declaration_value( $value ) ) {
+			return false;
+		}
+
+		$trimmed_style = rtrim( $this->style, self::WHITESPACE );
+		$insert_at     = strlen( $trimmed_style );
+		$separator     = $this->has_queued_append_at( $insert_at ) ? ' ' : '';
+
+		if ( '' === $separator && '' !== trim( $trimmed_style, self::WHITESPACE ) ) {
+			$separator = ( ';' === substr( $trimmed_style, -1 ) ) ? ' ' : '; ';
+		}
+
+		$this->queue_lexical_update(
+			$insert_at,
+			0,
+			$separator . $this->serialize_declaration( $property_name, $value, $important ),
+			null
+		);
+
+		return true;
+	}
+
+	/**
+	 * Returns the updated style attribute value.
+	 *
+	 * @return string Updated style attribute value.
+	 */
+	public function get_updated_style(): string {
+		if ( empty( $this->lexical_updates ) ) {
+			return $this->style;
+		}
+
+		usort(
+			$this->lexical_updates,
+			static function ( $a, $b ) {
+				if ( $a['start'] !== $b['start'] ) {
+					return $a['start'] - $b['start'];
+				}
+
+				return $a['order'] - $b['order'];
+			}
+		);
+
+		$updates = $this->merge_overlapping_lexical_updates( $this->lexical_updates );
+
+		$bytes_already_copied = 0;
+		$output               = '';
+
+		foreach ( $updates as $update ) {
+			$output              .= substr( $this->style, $bytes_already_copied, $update['start'] - $bytes_already_copied );
+			$output              .= $update['text'];
+			$bytes_already_copied = $update['start'] + $update['length'];
+		}
+
+		$output .= substr( $this->style, $bytes_already_copied );
+
+		return $output;
+	}
+
+	/**
+	 * Parses CSS tokens and declarations from the style attribute value.
+	 */
+	private function parse(): void {
+		$processor = WP_CSS_Token_Processor::create( $this->style );
+		if ( null === $processor ) {
+			return;
+		}
+
+		while ( $processor->next_token() ) {
+			$start          = $processor->get_token_start();
+			$length         = $processor->get_token_length();
+			$this->tokens[] = array(
+				'type'   => $processor->get_token_type(),
+				'value'  => $processor->get_token_value(),
+				'start'  => $start,
+				'length' => $length,
+				'end'    => $start + $length,
+			);
+		}
+
+		$this->parse_declaration_list();
+	}
+
+	/**
+	 * Parses the token list according to the CSS declaration-list shape.
+	 */
+	private function parse_declaration_list(): void {
+		$index                 = 0;
+		$count                 = count( $this->tokens );
+		$previous_item_ends_at = 0;
+
+		while ( $index < $count ) {
+			$leading_start = $previous_item_ends_at;
+			$index         = $this->skip_ignored_tokens( $index );
+
+			while ( $index < $count && WP_CSS_Token_Processor::TOKEN_SEMICOLON === $this->tokens[ $index ]['type'] ) {
+				$previous_item_ends_at = $this->tokens[ $index ]['end'];
+				$leading_start         = $previous_item_ends_at;
+				++$index;
+				$index = $this->skip_ignored_tokens( $index );
+			}
+
+			if ( $index >= $count ) {
+				break;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_AT_KEYWORD === $this->tokens[ $index ]['type'] ) {
+				list( $index, $previous_item_ends_at ) = $this->consume_at_rule( $index );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE === $this->tokens[ $index ]['type'] ) {
+				$previous_item_ends_at = $this->tokens[ $index ]['end'];
+				++$index;
+				continue;
+			}
+
+			list( $declaration_end, $after_declaration, $has_semicolon ) = $this->consume_declaration_segment( $index );
+			$declaration = $this->parse_declaration_segment( $leading_start, $index, $declaration_end, $after_declaration );
+
+			if ( null !== $declaration ) {
+				$declaration['trailing_end'] = $this->get_trailing_ignored_end( $declaration_end + ( $has_semicolon ? 1 : 0 ) );
+				$this->declarations[]        = $declaration;
+			}
+
+			$index                 = $declaration_end + ( $has_semicolon ? 1 : 0 );
+			$previous_item_ends_at = $after_declaration;
+		}
+	}
+
+	/**
+	 * Consumes an at-rule and returns the token index and byte offset after it.
+	 *
+	 * @param int $index At-keyword token index.
+	 * @return array{int,int} Token index and byte offset after the at-rule.
+	 */
+	private function consume_at_rule( int $index ): array {
+		$count = count( $this->tokens );
+		++$index;
+
+		while ( $index < $count ) {
+			$token = $this->tokens[ $index ];
+
+			if ( WP_CSS_Token_Processor::TOKEN_SEMICOLON === $token['type'] ) {
+				return array( $index + 1, $token['end'] );
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $token['type'] ) {
+				return $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE );
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET );
+				continue;
+			}
+
+			++$index;
+		}
+
+		$after = empty( $this->tokens ) ? strlen( $this->style ) : $this->tokens[ $count - 1 ]['end'];
+		return array( $count, $after );
+	}
+
+	/**
+	 * Consumes a simple block.
+	 *
+	 * @param int    $index        Token index for the opening token.
+	 * @param string $closing_type Expected closing token type.
+	 * @return array{int,int} Token index and byte offset after the block.
+	 */
+	private function consume_simple_block( int $index, string $closing_type ): array {
+		$count = count( $this->tokens );
+		++$index;
+
+		while ( $index < $count ) {
+			$token = $this->tokens[ $index ];
+
+			if ( $closing_type === $token['type'] ) {
+				return array( $index + 1, $token['end'] );
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE );
+				continue;
+			}
+
+			++$index;
+		}
+
+		$after = empty( $this->tokens ) ? strlen( $this->style ) : $this->tokens[ $count - 1 ]['end'];
+		return array( $count, $after );
+	}
+
+	/**
+	 * Consumes a declaration candidate up to the next top-level semicolon or EOF.
+	 *
+	 * @param int $index Starting token index.
+	 * @return array{int,int,bool} End token index, byte offset after candidate, and whether it ended in a semicolon.
+	 */
+	private function consume_declaration_segment( int $index ): array {
+		$count = count( $this->tokens );
+
+		while ( $index < $count ) {
+			$token = $this->tokens[ $index ];
+
+			if ( WP_CSS_Token_Processor::TOKEN_SEMICOLON === $token['type'] ) {
+				return array( $index, $token['end'], true );
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE );
+				continue;
+			}
+
+			++$index;
+		}
+
+		$after = empty( $this->tokens ) ? strlen( $this->style ) : $this->tokens[ $count - 1 ]['end'];
+		return array( $count, $after, false );
+	}
+
+	/**
+	 * Parses a declaration from a token segment.
+	 *
+	 * @param int $leading_start Byte offset before leading trivia.
+	 * @param int $start_index   First token index in the segment.
+	 * @param int $end_index     Token index after the segment.
+	 * @param int $after         Byte offset after the declaration.
+	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}|null
+	 */
+	private function parse_declaration_segment( int $leading_start, int $start_index, int $end_index, int $after ): ?array {
+		$index = $this->skip_ignored_tokens( $start_index, $end_index );
+		if ( $index >= $end_index || WP_CSS_Token_Processor::TOKEN_IDENT !== $this->tokens[ $index ]['type'] ) {
+			return null;
+		}
+
+		$name_token = $this->tokens[ $index ];
+		$name       = $name_token['value'];
+		if ( null === $name ) {
+			return null;
+		}
+
+		++$index;
+		$index = $this->skip_ignored_tokens( $index, $end_index );
+
+		if ( $index >= $end_index || WP_CSS_Token_Processor::TOKEN_COLON !== $this->tokens[ $index ]['type'] ) {
+			return null;
+		}
+
+		$colon_token       = $this->tokens[ $index ];
+		$value_start_index = $this->skip_ignored_tokens( $index + 1, $end_index );
+		$value_end_index   = $this->trim_ignored_tokens( $value_start_index, $end_index );
+		$important         = false;
+		$top_level_tokens  = $this->get_top_level_non_ignored_token_indexes( $value_start_index, $value_end_index );
+		$top_level_count   = count( $top_level_tokens );
+		$last_value_index  = $top_level_count > 0 ? $top_level_tokens[ $top_level_count - 1 ] : null;
+		$before_last_index = $top_level_count > 1 ? $top_level_tokens[ $top_level_count - 2 ] : null;
+
+		if (
+			null !== $last_value_index &&
+			null !== $before_last_index &&
+			WP_CSS_Token_Processor::TOKEN_IDENT === $this->tokens[ $last_value_index ]['type'] &&
+			0 === strcasecmp( 'important', (string) $this->tokens[ $last_value_index ]['value'] ) &&
+			WP_CSS_Token_Processor::TOKEN_DELIM === $this->tokens[ $before_last_index ]['type'] &&
+			'!' === $this->tokens[ $before_last_index ]['value']
+		) {
+			$important       = true;
+			$value_end_index = $this->trim_ignored_tokens( $value_start_index, $before_last_index );
+		}
+
+		if ( $value_start_index >= $value_end_index ) {
+			$value_start = $colon_token['end'];
+			$value_end   = $colon_token['end'];
+		} else {
+			$value_start = $this->tokens[ $value_start_index ]['start'];
+			$value_end   = $this->tokens[ $value_end_index - 1 ]['end'];
+		}
+
+		return array(
+			'name'          => $name,
+			'raw_name'      => substr( $this->style, $name_token['start'], $name_token['length'] ),
+			'leading_start' => $leading_start,
+			'start'         => $name_token['start'],
+			'after'         => $after,
+			'trailing_end'  => $after,
+			'value_start'   => $value_start,
+			'value_end'     => $value_end,
+			'important'     => $important,
+		);
+	}
+
+	/**
+	 * Gets top-level non-ignored token indexes from a token range.
+	 *
+	 * @param int $start Start token index.
+	 * @param int $end   End token index.
+	 * @return int[] Top-level non-ignored token indexes.
+	 */
+	private function get_top_level_non_ignored_token_indexes( int $start, int $end ): array {
+		$top_level_tokens = array();
+		$index            = $start;
+
+		while ( $index < $end ) {
+			$token = $this->tokens[ $index ];
+
+			if ( $this->is_ignored_token( $token ) ) {
+				++$index;
+				continue;
+			}
+
+			$top_level_tokens[] = $index;
+
+			if ( WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET );
+				continue;
+			}
+
+			if ( WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $token['type'] ) {
+				list( $index ) = $this->consume_simple_block( $index, WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE );
+				continue;
+			}
+
+			++$index;
+		}
+
+		return $top_level_tokens;
+	}
+
+	/**
+	 * Skips ignored CSS tokens.
+	 *
+	 * @param int      $index Token index.
+	 * @param int|null $end   Optional token index at which to stop.
+	 * @return int Token index after ignored tokens.
+	 */
+	private function skip_ignored_tokens( int $index, ?int $end = null ): int {
+		$end = null === $end ? count( $this->tokens ) : $end;
+
+		while ( $index < $end && $this->is_ignored_token( $this->tokens[ $index ] ) ) {
+			++$index;
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Trims ignored CSS tokens from the end of a token range.
+	 *
+	 * @param int $start Start token index.
+	 * @param int $end   End token index.
+	 * @return int Trimmed end token index.
+	 */
+	private function trim_ignored_tokens( int $start, int $end ): int {
+		while ( $end > $start && $this->is_ignored_token( $this->tokens[ $end - 1 ] ) ) {
+			--$end;
+		}
+
+		return $end;
+	}
+
+	/**
+	 * Gets the byte offset after ignored tokens beginning at a token index.
+	 *
+	 * @param int $index Token index.
+	 * @return int Byte offset after ignored tokens.
+	 */
+	private function get_trailing_ignored_end( int $index ): int {
+		$end   = $index > 0 && isset( $this->tokens[ $index - 1 ] ) ? $this->tokens[ $index - 1 ]['end'] : 0;
+		$count = count( $this->tokens );
+
+		while ( $index < $count && $this->is_ignored_token( $this->tokens[ $index ] ) ) {
+			$end = $this->tokens[ $index ]['end'];
+			++$index;
+		}
+
+		return $end;
+	}
+
+	/**
+	 * Checks whether a token is ignored by declaration-list grammar.
+	 *
+	 * @param array{type:string, value:string|null, start:int, length:int, end:int} $token Token metadata.
+	 * @return bool Whether the token is ignored.
+	 */
+	private function is_ignored_token( array $token ): bool {
+		return (
+			WP_CSS_Token_Processor::TOKEN_WHITESPACE === $token['type'] ||
+			WP_CSS_Token_Processor::TOKEN_COMMENT === $token['type']
+		);
+	}
+
+	/**
+	 * Gets the current declaration metadata.
+	 *
+	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}|null
+	 */
+	private function get_current_declaration(): ?array {
+		if ( $this->current_declaration < 0 || ! isset( $this->declarations[ $this->current_declaration ] ) ) {
+			return null;
+		}
+
+		return $this->declarations[ $this->current_declaration ];
+	}
+
+	/**
+	 * Queues a lexical update, replacing any earlier update for the same declaration.
+	 *
+	 * @param int      $start       Byte offset at which to start the update.
+	 * @param int      $length      Number of bytes to replace.
+	 * @param string   $text        Replacement text.
+	 * @param int|null $declaration Declaration index associated with the update.
+	 */
+	private function queue_lexical_update( int $start, int $length, string $text, ?int $declaration ): void {
+		if ( null !== $declaration ) {
+			foreach ( $this->lexical_updates as $index => $update ) {
+				if ( $update['declaration'] === $declaration ) {
+					unset( $this->lexical_updates[ $index ] );
+				}
+			}
+		}
+
+		$this->lexical_updates[] = array(
+			'start'       => $start,
+			'length'      => $length,
+			'text'        => $text,
+			'declaration' => $declaration,
+			'order'       => $this->lexical_update_order++,
+		);
+	}
+
+	/**
+	 * Checks whether an append has already been queued at a byte offset.
+	 *
+	 * @param int $insert_at Byte offset.
+	 * @return bool Whether an append has already been queued at the offset.
+	 */
+	private function has_queued_append_at( int $insert_at ): bool {
+		foreach ( $this->lexical_updates as $update ) {
+			if ( null === $update['declaration'] && $insert_at === $update['start'] && 0 === $update['length'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Merges overlapping lexical updates into non-overlapping replacements.
+	 *
+	 * Adjacent declaration removals may share separator whitespace, and appends
+	 * may be queued inside a range removed from the original style. This method
+	 * collapses those updates while preserving the requested replacement text.
+	 *
+	 * @param array<int, array{start:int, length:int, text:string, declaration:int|null, order:int}> $updates Lexical updates.
+	 * @return array<int, array{start:int, length:int, text:string, declaration:int|null, order:int}> Merged updates.
+	 */
+	private function merge_overlapping_lexical_updates( array $updates ): array {
+		$merged = array();
+
+		foreach ( $updates as $update ) {
+			if ( empty( $merged ) ) {
+				$merged[] = $update;
+				continue;
+			}
+
+			$last_index = count( $merged ) - 1;
+			$last       = $merged[ $last_index ];
+			$last_end   = $last['start'] + $last['length'];
+			$update_end = $update['start'] + $update['length'];
+
+			if ( $update['start'] > $last_end ) {
+				$merged[] = $update;
+				continue;
+			}
+
+			$text = $update['text'];
+			if ( 0 === $last['start'] && '' === $last['text'] && 0 === $update['length'] ) {
+				$text = ltrim( $text, ';' . self::WHITESPACE );
+			}
+
+			$merged[ $last_index ]['length'] = max( $last_end, $update_end ) - $last['start'];
+			$merged[ $last_index ]['text']   = $last['text'] . $text;
+		}
+
+		foreach ( $merged as $index => $update ) {
+			if ( 0 !== $update['start'] || '' !== $update['text'] ) {
+				continue;
+			}
+
+			$end = $update['length'];
+			while ( $end < strlen( $this->style ) && false !== strpos( self::WHITESPACE, $this->style[ $end ] ) ) {
+				++$end;
+			}
+
+			$merged[ $index ]['length'] = $end;
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Serializes a declaration.
+	 *
+	 * @param string $property_name CSS property name.
+	 * @param string $value         CSS declaration value.
+	 * @param bool   $important     Whether to append !important.
+	 * @return string Serialized declaration.
+	 */
+	private function serialize_declaration( string $property_name, string $value, bool $important ): string {
+		$value = trim( $value, self::WHITESPACE );
+		return $property_name . ': ' . $value . ( $important ? ' !important' : '' ) . ';';
+	}
+
+	/**
+	 * Checks whether two property names match.
+	 *
+	 * @param string $actual Property name from a declaration.
+	 * @param string $query  Queried property name.
+	 * @return bool Whether the property names match.
+	 */
+	private function matches_property_name( string $actual, string $query ): bool {
+		if ( $this->is_custom_property_name( $actual ) || $this->is_custom_property_name( $query ) ) {
+			return $actual === $query;
+		}
+
+		return 0 === strcasecmp( $actual, $query );
+	}
+
+	/**
+	 * Checks whether a property name is a custom property.
+	 *
+	 * @param string $property_name Property name.
+	 * @return bool Whether this is a custom property name.
+	 */
+	private function is_custom_property_name( string $property_name ): bool {
+		return strlen( $property_name ) >= 2 && '--' === substr( $property_name, 0, 2 );
+	}
+
+	/**
+	 * Checks whether a CSS property name is syntactically valid.
+	 *
+	 * @param string $property_name CSS property name.
+	 * @return bool Whether the property name is valid.
+	 */
+	private function is_valid_property_name( string $property_name ): bool {
+		$processor = WP_CSS_Token_Processor::create( $property_name );
+		if ( null === $processor || ! $processor->next_token() ) {
+			return false;
+		}
+
+		if (
+			WP_CSS_Token_Processor::TOKEN_IDENT !== $processor->get_token_type() ||
+			$processor->get_token_start() !== 0 ||
+			$processor->get_token_length() !== strlen( $property_name )
+		) {
+			return false;
+		}
+
+		if ( $processor->next_token() ) {
+			return false;
+		}
+
+		$sentinel_processor = WP_CSS_Token_Processor::create( $property_name . ': sentinel' );
+		if ( null === $sentinel_processor || ! $sentinel_processor->next_token() ) {
+			return false;
+		}
+
+		if (
+			WP_CSS_Token_Processor::TOKEN_IDENT !== $sentinel_processor->get_token_type() ||
+			$sentinel_processor->get_token_start() !== 0 ||
+			$sentinel_processor->get_token_length() !== strlen( $property_name )
+		) {
+			return false;
+		}
+
+		return (
+			$sentinel_processor->next_token() &&
+			WP_CSS_Token_Processor::TOKEN_COLON === $sentinel_processor->get_token_type()
+		);
+	}
+
+	/**
+	 * Checks whether a CSS declaration value is syntactically safe to insert.
+	 *
+	 * @param string $value CSS declaration value.
+	 * @return bool Whether the value is valid.
+	 */
+	private function is_valid_declaration_value( string $value ): bool {
+		$sentinel_property = '--wp-style-attribute-processor-sentinel';
+		$processor         = WP_CSS_Token_Processor::create( $value . ';' . $sentinel_property . ':1' );
+		if ( null === $processor ) {
+			return false;
+		}
+
+		$stack            = array();
+		$top_level_tokens = array();
+		$found_sentinel   = false;
+
+		while ( $processor->next_token() ) {
+			$type = $processor->get_token_type();
+
+			if ( empty( $stack ) && WP_CSS_Token_Processor::TOKEN_WHITESPACE !== $type && WP_CSS_Token_Processor::TOKEN_COMMENT !== $type ) {
+				if ( WP_CSS_Token_Processor::TOKEN_SEMICOLON === $type ) {
+					if ( strlen( $value ) !== $processor->get_token_start() ) {
+						return false;
+					}
+
+					$found_sentinel = true;
+					break;
+				}
+
+				$top_level_tokens[] = array(
+					'type'  => $type,
+					'value' => $processor->get_token_value(),
+				);
+			}
+
+			switch ( $type ) {
+				case WP_CSS_Token_Processor::TOKEN_SEMICOLON:
+					if ( empty( $stack ) ) {
+						return false;
+					}
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_BAD_STRING:
+				case WP_CSS_Token_Processor::TOKEN_BAD_URL:
+					return false;
+
+				case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+				case WP_CSS_Token_Processor::TOKEN_LEFT_PAREN:
+					$stack[] = WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN;
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET:
+					$stack[] = WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET;
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACE:
+					$stack[] = WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE;
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET:
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE:
+					if ( empty( $stack ) || array_pop( $stack ) !== $processor->get_token_type() ) {
+						return false;
+					}
+					break;
+			}
+		}
+
+		if ( ! $found_sentinel || ! empty( $stack ) ) {
+			return false;
+		}
+
+		$top_level_count = count( $top_level_tokens );
+		if ( $top_level_count < 2 ) {
+			return true;
+		}
+
+		$last_value_token  = $top_level_tokens[ $top_level_count - 1 ];
+		$before_last_token = $top_level_tokens[ $top_level_count - 2 ];
+
+		return ! (
+			WP_CSS_Token_Processor::TOKEN_IDENT === $last_value_token['type'] &&
+			0 === strcasecmp( 'important', (string) $last_value_token['value'] ) &&
+			WP_CSS_Token_Processor::TOKEN_DELIM === $before_last_token['type'] &&
+			'!' === $before_last_token['value']
+		);
+	}
+}

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -202,18 +202,14 @@ class WP_HTML_Style_Attribute_Processor {
 			return false;
 		}
 
-		if ( '' === trim( substr( $this->style, 0, $declaration['leading_start'] ), self::WHITESPACE ) ) {
-			$remove_start = $declaration['leading_start'];
-			$remove_end   = $declaration['trailing_end'];
-		} else {
-			$remove_start = $declaration['leading_start'];
-			$remove_end   = $declaration['after'];
-		}
+		$remove_start = $this->get_offset_before_preceding_whitespace( $declaration['start'] );
+		$remove_end   = $this->get_offset_after_following_whitespace( $declaration['after'] );
+		$replacement  = ( $remove_start > 0 && $remove_end < strlen( $this->style ) ) ? ' ' : '';
 
 		$this->queue_lexical_update(
 			$remove_start,
 			$remove_end - $remove_start,
-			'',
+			$replacement,
 			$this->current_declaration
 		);
 
@@ -679,6 +675,36 @@ class WP_HTML_Style_Attribute_Processor {
 			WP_CSS_Token_Processor::TOKEN_WHITESPACE === $token['type'] ||
 			WP_CSS_Token_Processor::TOKEN_COMMENT === $token['type']
 		);
+	}
+
+	/**
+	 * Gets the byte offset before contiguous whitespace ending at an offset.
+	 *
+	 * @param int $offset Byte offset.
+	 * @return int Offset before preceding whitespace.
+	 */
+	private function get_offset_before_preceding_whitespace( int $offset ): int {
+		while ( $offset > 0 && false !== strpos( self::WHITESPACE, $this->style[ $offset - 1 ] ) ) {
+			--$offset;
+		}
+
+		return $offset;
+	}
+
+	/**
+	 * Gets the byte offset after contiguous whitespace beginning at an offset.
+	 *
+	 * @param int $offset Byte offset.
+	 * @return int Offset after following whitespace.
+	 */
+	private function get_offset_after_following_whitespace( int $offset ): int {
+		$length = strlen( $this->style );
+
+		while ( $offset < $length && false !== strpos( self::WHITESPACE, $this->style[ $offset ] ) ) {
+			++$offset;
+		}
+
+		return $offset;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -15,10 +15,12 @@
  * delimiting braces. It does not parse HTML attribute syntax, decode character
  * references, or operate on raw HTML markup.
  *
- * Values read from {@see WP_HTML_Tag_Processor::get_attribute()} can be passed
- * directly to this class, and values returned by
+ * String values read from {@see WP_HTML_Tag_Processor::get_attribute()} can be
+ * passed to this class, and values returned by
  * {@see WP_HTML_Style_Attribute_Processor::get_updated_style()} can be passed
- * back to {@see WP_HTML_Tag_Processor::set_attribute()}.
+ * back to {@see WP_HTML_Tag_Processor::set_attribute()}. Missing and boolean
+ * style attributes are an HTML concern and must be handled before creating this
+ * processor.
  *
  * Unlike associative-array based style helpers, this processor preserves the
  * declaration list model of CSS. Multiple declarations with the same property
@@ -32,7 +34,7 @@ class WP_HTML_Style_Attribute_Processor {
 	 *
 	 * @var string
 	 */
-	const WHITESPACE = " \t\n\r\f";
+	private const WHITESPACE = " \t\n\r\f";
 
 	/**
 	 * Decoded style attribute value.
@@ -51,7 +53,7 @@ class WP_HTML_Style_Attribute_Processor {
 	/**
 	 * Parsed declarations.
 	 *
-	 * @var array<int, array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}>
+	 * @var array<int, array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool, important_start:int|null, important_end:int|null}>
 	 */
 	private $declarations = array();
 
@@ -93,16 +95,27 @@ class WP_HTML_Style_Attribute_Processor {
 	/**
 	 * Constructor.
 	 *
-	 * @param string|bool|null $style Decoded CSS text value from a style attribute.
+	 * Do not instantiate directly. Use
+	 * {@see WP_HTML_Style_Attribute_Processor::create()} instead.
+	 *
+	 * @param string $style Decoded CSS text value from a style attribute.
 	 */
-	public function __construct( $style = '' ) {
-		if ( null === $style || true === $style ) {
-			$style = '';
-		} elseif ( ! is_string( $style ) ) {
-			$style = '';
+	private function __construct( string $style ) {
+		$this->style = $style;
+	}
+
+	/**
+	 * Creates a processor for decoded CSS text from a style attribute.
+	 *
+	 * @param string $decoded_css_text Decoded CSS text value from a style attribute.
+	 * @return static Created processor.
+	 */
+	public static function create( $decoded_css_text ) {
+		if ( ! is_string( $decoded_css_text ) ) {
+			throw new TypeError( __METHOD__ . '(): Argument #1 ($decoded_css_text) must be of type string' );
 		}
 
-		$this->style = $style;
+		return new static( $decoded_css_text );
 	}
 
 	/**
@@ -144,32 +157,14 @@ class WP_HTML_Style_Attribute_Processor {
 	}
 
 	/**
-	 * Gets the current declaration's CSS value.
-	 *
-	 * The returned value does not include a trailing !important priority.
-	 *
-	 * @return string|null CSS value, or null when not on a declaration.
-	 */
-	public function get_value(): ?string {
-		$declaration = $this->get_current_declaration();
-		if ( null === $declaration ) {
-			return null;
-		}
-
-		return trim(
-			substr( $this->style, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
-			self::WHITESPACE
-		);
-	}
-
-	/**
 	 * Indicates whether the current declaration has an !important priority.
 	 *
-	 * @return bool Whether the current declaration has an !important priority.
+	 * @return bool|null Whether the current declaration has an !important priority,
+	 *                   or null when not on a declaration.
 	 */
-	public function is_important(): bool {
+	public function is_important(): ?bool {
 		$declaration = $this->get_current_declaration();
-		return null !== $declaration && $declaration['important'];
+		return null === $declaration ? null : $declaration['important'];
 	}
 
 	/**
@@ -182,12 +177,37 @@ class WP_HTML_Style_Attribute_Processor {
 	 */
 	public function set_value( string $value, ?bool $important = null ): bool {
 		$declaration = $this->get_current_declaration();
-		if ( null === $declaration || ! $this->is_valid_declaration_value( $value ) ) {
+		if ( null === $declaration ) {
+			return false;
+		}
+
+		if ( '' === $value ) {
+			return $this->remove_declaration();
+		}
+
+		if ( ! $this->is_valid_declaration_value( $value ) ) {
 			return false;
 		}
 
 		$is_important = null === $important ? $declaration['important'] : $important;
 		$text         = $this->serialize_declaration( $declaration['raw_name'], $value, $is_important );
+		$parsed_value = $this->get_parsed_declaration_value( $text );
+		if ( null === $parsed_value ) {
+			return false;
+		}
+
+		if (
+			! $this->is_current_declaration_replacement_safe(
+				$declaration,
+				$declaration['start'],
+				$declaration['after'] - $declaration['start'],
+				$text,
+				$is_important,
+				$parsed_value
+			)
+		) {
+			return false;
+		}
 
 		$this->queue_lexical_update(
 			$declaration['start'],
@@ -195,6 +215,98 @@ class WP_HTML_Style_Attribute_Processor {
 			$text,
 			$this->current_declaration
 		);
+
+		$this->apply_lexical_updates( $this->current_declaration );
+
+		return true;
+	}
+
+	/**
+	 * Sets the !important priority of the current declaration.
+	 *
+	 * @param bool $important Whether the declaration should be important.
+	 * @return bool Whether the current declaration priority is set as requested.
+	 */
+	public function set_important( bool $important ): bool {
+		$declaration = $this->get_current_declaration();
+		if ( null === $declaration ) {
+			return false;
+		}
+
+		if ( $important === $declaration['important'] ) {
+			return true;
+		}
+
+		if ( $important ) {
+			if ( $declaration['value_start'] >= $declaration['value_end'] ) {
+				return false;
+			}
+
+			$insert_at   = $declaration['value_end'];
+			$insert_text = ' !important';
+			if (
+				! $this->is_current_declaration_replacement_safe(
+					$declaration,
+					$declaration['value_end'],
+					0,
+					$insert_text,
+					true
+				)
+			) {
+				$eof_repair    = strlen( $this->style ) === $declaration['after']
+					? $this->get_eof_repair( $declaration['after'] )
+					: null;
+				$current_value = substr( $this->style, $declaration['value_start'], $declaration['after'] - $declaration['value_start'] );
+
+				if (
+					null === $eof_repair ||
+					'' === $eof_repair ||
+					! $this->is_current_declaration_replacement_safe(
+						$declaration,
+						$declaration['after'],
+						0,
+						$eof_repair . $insert_text,
+						true,
+						trim( $current_value . $eof_repair, self::WHITESPACE )
+					)
+				) {
+					return false;
+				}
+
+				$insert_at   = $declaration['after'];
+				$insert_text = $eof_repair . $insert_text;
+			}
+
+			$this->queue_lexical_update(
+				$insert_at,
+				0,
+				$insert_text,
+				$this->current_declaration
+			);
+		} else {
+			if ( null === $declaration['important_start'] || null === $declaration['important_end'] ) {
+				return false;
+			}
+
+			if (
+				! $this->is_current_declaration_replacement_safe(
+					$declaration,
+					$declaration['important_start'],
+					$declaration['important_end'] - $declaration['important_start'],
+					'',
+					false
+				)
+			) {
+				return false;
+			}
+
+			$this->queue_lexical_update(
+				$declaration['important_start'],
+				$declaration['important_end'] - $declaration['important_start'],
+				'',
+				$this->current_declaration
+			);
+		}
 
 		$this->apply_lexical_updates( $this->current_declaration );
 
@@ -218,6 +330,10 @@ class WP_HTML_Style_Attribute_Processor {
 		$remove_start = $this->get_offset_before_preceding_whitespace( $declaration['start'] );
 		$remove_end   = $this->get_offset_after_following_whitespace( $declaration['after'] );
 		$replacement  = ( $remove_start > 0 && $remove_end < strlen( $this->style ) ) ? ' ' : '';
+
+		if ( ! $this->is_remove_declaration_safe( $this->current_declaration, $remove_start, $remove_end - $remove_start, $replacement ) ) {
+			return false;
+		}
 
 		$this->queue_lexical_update(
 			$remove_start,
@@ -243,7 +359,11 @@ class WP_HTML_Style_Attribute_Processor {
 	 * @return bool Whether the declaration was appended.
 	 */
 	public function append_declaration( string $property_name, string $value, bool $important = false ): bool {
-		if ( ! $this->is_valid_property_name( $property_name ) || ! $this->is_valid_declaration_value( $value ) ) {
+		if (
+			'' === trim( $value, self::WHITESPACE ) ||
+			! $this->is_valid_property_name( $property_name ) ||
+			! $this->is_valid_declaration_value( $value )
+		) {
 			return false;
 		}
 
@@ -252,17 +372,28 @@ class WP_HTML_Style_Attribute_Processor {
 		$old_declaration_count = count( $this->declarations );
 		$trimmed_style         = rtrim( $this->style, self::WHITESPACE );
 		$insert_at             = strlen( $trimmed_style );
-		$separator             = $this->get_append_separator( $insert_at );
-		$declaration_text      = $this->serialize_declaration( $property_name, $value, $important );
+		$repair_at             = strlen( $this->style );
+		$eof_repair            = $this->get_eof_repair( $repair_at );
+		if ( null === $eof_repair ) {
+			return false;
+		}
 
-		if ( ! $this->is_parseable_append( $insert_at, $separator, $declaration_text, $old_declaration_count ) ) {
+		$separator        = $this->get_append_separator( $insert_at );
+		$serialized_name  = $this->is_custom_property_name( $property_name ) ? $property_name : strtolower( $property_name );
+		$declaration_text = $this->serialize_declaration( $serialized_name, $value, $important );
+		$parsed_value     = $this->get_parsed_declaration_value( $declaration_text );
+		if ( null === $parsed_value ) {
+			return false;
+		}
+
+		if ( ! $this->is_parseable_append( $repair_at, $eof_repair, $separator, $declaration_text, $old_declaration_count, $serialized_name, $parsed_value, $important ) ) {
 			return false;
 		}
 
 		$this->queue_lexical_update(
-			$insert_at,
+			$repair_at,
 			0,
-			$separator . $declaration_text,
+			$eof_repair . $separator . $declaration_text,
 			null
 		);
 
@@ -535,7 +666,7 @@ class WP_HTML_Style_Attribute_Processor {
 	 * @param int $start_index   First token index in the segment.
 	 * @param int $end_index     Token index after the segment.
 	 * @param int $after         Byte offset after the declaration.
-	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}|null
+	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool, important_start:int|null, important_end:int|null}|null
 	 */
 	private function parse_declaration_segment( int $leading_start, int $start_index, int $end_index, int $after ): ?array {
 		$index = $this->skip_ignored_tokens( $start_index, $end_index );
@@ -549,6 +680,8 @@ class WP_HTML_Style_Attribute_Processor {
 			return null;
 		}
 
+		$name = $this->is_custom_property_name( $name ) ? $name : strtolower( $name );
+
 		++$index;
 		$index = $this->skip_ignored_tokens( $index, $end_index );
 
@@ -560,6 +693,8 @@ class WP_HTML_Style_Attribute_Processor {
 		$value_start_index = $this->skip_ignored_tokens( $index + 1, $end_index );
 		$value_end_index   = $this->trim_ignored_tokens( $value_start_index, $end_index );
 		$important         = false;
+		$important_start   = null;
+		$important_end     = null;
 		$top_level_tokens  = $this->get_top_level_non_ignored_token_indexes( $value_start_index, $value_end_index );
 		$top_level_count   = count( $top_level_tokens );
 		$last_value_index  = $top_level_count > 0 ? $top_level_tokens[ $top_level_count - 1 ] : null;
@@ -574,6 +709,8 @@ class WP_HTML_Style_Attribute_Processor {
 			'!' === $this->tokens[ $before_last_index ]['value']
 		) {
 			$important       = true;
+			$important_start = $this->tokens[ $before_last_index ]['start'];
+			$important_end   = $this->tokens[ $last_value_index ]['end'];
 			$value_end_index = $this->trim_ignored_tokens( $value_start_index, $before_last_index );
 		}
 
@@ -586,15 +723,17 @@ class WP_HTML_Style_Attribute_Processor {
 		}
 
 		return array(
-			'name'          => $name,
-			'raw_name'      => substr( $this->style, $name_token['start'], $name_token['length'] ),
-			'leading_start' => $leading_start,
-			'start'         => $name_token['start'],
-			'after'         => $after,
-			'trailing_end'  => $after,
-			'value_start'   => $value_start,
-			'value_end'     => $value_end,
-			'important'     => $important,
+			'name'            => $name,
+			'raw_name'        => substr( $this->style, $name_token['start'], $name_token['length'] ),
+			'leading_start'   => $leading_start,
+			'start'           => $name_token['start'],
+			'after'           => $after,
+			'trailing_end'    => $after,
+			'value_start'     => $value_start,
+			'value_end'       => $value_end,
+			'important'       => $important,
+			'important_start' => $important_start,
+			'important_end'   => $important_end,
 		);
 	}
 
@@ -741,7 +880,7 @@ class WP_HTML_Style_Attribute_Processor {
 	/**
 	 * Gets the current declaration metadata.
 	 *
-	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool}|null
+	 * @return array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool, important_start:int|null, important_end:int|null}|null
 	 */
 	private function get_current_declaration(): ?array {
 		if (
@@ -753,6 +892,122 @@ class WP_HTML_Style_Attribute_Processor {
 		}
 
 		return $this->declarations[ $this->current_declaration ];
+	}
+
+	/**
+	 * Checks whether a replacement preserves the current declaration's structure.
+	 *
+	 * @param array{name:string, raw_name:string, leading_start:int, start:int, after:int, trailing_end:int, value_start:int, value_end:int, important:bool, important_start:int|null, important_end:int|null} $declaration        Current declaration metadata.
+	 * @param int                                                                                                                                                                                   $start              Byte offset at which to start the replacement.
+	 * @param int                                                                                                                                                                                   $length             Number of bytes to replace.
+	 * @param string                                                                                                                                                                                $text               Replacement text.
+	 * @param bool                                                                                                                                                                                  $expected_important Expected important flag after replacement.
+	 * @param string|null                                                                                                                                                                           $expected_value     Optional expected value source after replacement.
+	 * @return bool Whether the replacement is safe.
+	 */
+	private function is_current_declaration_replacement_safe( array $declaration, int $start, int $length, string $text, bool $expected_important, ?string $expected_value = null ): bool {
+		$candidate_style = substr( $this->style, 0, $start ) . $text . substr( $this->style, $start + $length );
+		$candidate       = new self( $candidate_style );
+		$candidate->ensure_parsed();
+
+		if (
+			count( $candidate->declarations ) !== count( $this->declarations ) ||
+			! isset( $candidate->declarations[ $this->current_declaration ] )
+		) {
+			return false;
+		}
+
+		$updated_declaration = $candidate->declarations[ $this->current_declaration ];
+		if (
+			$updated_declaration['name'] !== $declaration['name'] ||
+			$updated_declaration['important'] !== $expected_important
+		) {
+			return false;
+		}
+
+		$old_value = trim(
+			substr( $this->style, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
+			self::WHITESPACE
+		);
+		$new_value = trim(
+			substr( $candidate_style, $updated_declaration['value_start'], $updated_declaration['value_end'] - $updated_declaration['value_start'] ),
+			self::WHITESPACE
+		);
+
+		return null === $expected_value ? $old_value === $new_value : $expected_value === $new_value;
+	}
+
+	/**
+	 * Checks whether removing a declaration preserves remaining structure.
+	 *
+	 * @param int    $removed_declaration Removed declaration index.
+	 * @param int    $start               Byte offset at which to start the replacement.
+	 * @param int    $length              Number of bytes to replace.
+	 * @param string $text                Replacement text.
+	 * @return bool Whether the removal is safe.
+	 */
+	private function is_remove_declaration_safe( int $removed_declaration, int $start, int $length, string $text ): bool {
+		$candidate_style = substr( $this->style, 0, $start ) . $text . substr( $this->style, $start + $length );
+		$candidate       = new self( $candidate_style );
+		$candidate->ensure_parsed();
+
+		if ( count( $candidate->declarations ) !== count( $this->declarations ) - 1 ) {
+			return false;
+		}
+
+		$candidate_index = 0;
+		foreach ( $this->declarations as $index => $declaration ) {
+			if ( $removed_declaration === $index ) {
+				continue;
+			}
+
+			if ( ! isset( $candidate->declarations[ $candidate_index ] ) ) {
+				return false;
+			}
+
+			$candidate_declaration = $candidate->declarations[ $candidate_index ];
+			$value                 = trim(
+				substr( $this->style, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
+				self::WHITESPACE
+			);
+			$candidate_value       = trim(
+				substr( $candidate_style, $candidate_declaration['value_start'], $candidate_declaration['value_end'] - $candidate_declaration['value_start'] ),
+				self::WHITESPACE
+			);
+
+			if (
+				$candidate_declaration['name'] !== $declaration['name'] ||
+				$candidate_declaration['important'] !== $declaration['important'] ||
+				$candidate_value !== $value
+			) {
+				return false;
+			}
+
+			++$candidate_index;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the parsed value source from a serialized declaration.
+	 *
+	 * @param string $declaration_text Serialized declaration text.
+	 * @return string|null Parsed declaration value, or null if parsing failed.
+	 */
+	private function get_parsed_declaration_value( string $declaration_text ): ?string {
+		$processor = new self( $declaration_text );
+		$processor->ensure_parsed();
+
+		if ( 1 !== count( $processor->declarations ) ) {
+			return null;
+		}
+
+		$declaration = $processor->declarations[0];
+		return trim(
+			substr( $declaration_text, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
+			self::WHITESPACE
+		);
 	}
 
 	/**
@@ -894,6 +1149,107 @@ class WP_HTML_Style_Attribute_Processor {
 	}
 
 	/**
+	 * Gets required closing delimiters before appending at EOF.
+	 *
+	 * CSS closes unterminated functions and simple blocks at EOF. Appending must
+	 * materialize those closers before adding a new declaration.
+	 *
+	 * @param int $insert_at Byte offset at which the declaration will be inserted.
+	 * @return string|null Closing delimiters, or null when repair cannot be precise.
+	 */
+	private function get_eof_repair( int $insert_at ): ?string {
+		$stack = array();
+
+		foreach ( $this->tokens as $token ) {
+			if ( $token['start'] >= $insert_at ) {
+				break;
+			}
+
+			if ( $token['end'] > $insert_at ) {
+				return null;
+			}
+
+			switch ( $token['type'] ) {
+				case WP_CSS_Token_Processor::TOKEN_BAD_STRING:
+				case WP_CSS_Token_Processor::TOKEN_BAD_URL:
+					return null;
+
+				case WP_CSS_Token_Processor::TOKEN_COMMENT:
+					if (
+						strlen( $this->style ) === $token['end'] &&
+						'*/' !== substr( $this->style, -2 )
+					) {
+						return null;
+					}
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+				case WP_CSS_Token_Processor::TOKEN_LEFT_PAREN:
+					$stack[] = ')';
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_URL:
+					if ( ! $this->is_url_token_closed( $token ) ) {
+						$stack[] = ')';
+					}
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET:
+					$stack[] = ']';
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_LEFT_BRACE:
+					$stack[] = '}';
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+					if ( ! empty( $stack ) && ')' === end( $stack ) ) {
+						array_pop( $stack );
+					}
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET:
+					if ( ! empty( $stack ) && ']' === end( $stack ) ) {
+						array_pop( $stack );
+					}
+					break;
+
+				case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE:
+					if ( ! empty( $stack ) && '}' === end( $stack ) ) {
+						array_pop( $stack );
+					}
+					break;
+			}
+		}
+
+		return implode( '', array_reverse( $stack ) );
+	}
+
+	/**
+	 * Checks whether a URL token source contains its real closing parenthesis.
+	 *
+	 * @param array{type:string, value:string|null, start:int, length:int, end:int} $token URL token metadata.
+	 * @return bool Whether the URL token was closed in source.
+	 */
+	private function is_url_token_closed( array $token ): bool {
+		$sentinel = ' !wp-style-attribute-processor-sentinel';
+		$source   = substr( $this->style, $token['start'], $token['length'] );
+		$scanner  = WP_CSS_Token_Processor::create( $source . $sentinel );
+		if ( null === $scanner || ! $scanner->next_token() ) {
+			return false;
+		}
+
+		if (
+			WP_CSS_Token_Processor::TOKEN_URL !== $scanner->get_token_type() ||
+			$scanner->get_token_length() > strlen( $source )
+		) {
+			return false;
+		}
+
+		return $scanner->next_token();
+	}
+
+	/**
 	 * Checks whether an appended declaration will parse as a new declaration.
 	 *
 	 * Malformed existing declarations can leave the append point inside an
@@ -901,15 +1257,19 @@ class WP_HTML_Style_Attribute_Processor {
 	 * appending a top-level declaration are incompatible.
 	 *
 	 * @param int    $insert_at             Byte offset at which the declaration will be inserted.
+	 * @param string $eof_repair            EOF repair text.
 	 * @param string $separator             Separator text.
 	 * @param string $declaration_text      Serialized declaration text.
 	 * @param int    $old_declaration_count Number of declarations before appending.
+	 * @param string $expected_name          Expected parsed property name.
+	 * @param string $expected_value         Expected parsed value source.
+	 * @param bool   $expected_important     Expected important flag.
 	 * @return bool Whether the appended declaration is parseable.
 	 */
-	private function is_parseable_append( int $insert_at, string $separator, string $declaration_text, int $old_declaration_count ): bool {
-		$expected_start  = $insert_at + strlen( $separator );
+	private function is_parseable_append( int $insert_at, string $eof_repair, string $separator, string $declaration_text, int $old_declaration_count, string $expected_name, string $expected_value, bool $expected_important ): bool {
+		$expected_start  = $insert_at + strlen( $eof_repair ) + strlen( $separator );
 		$expected_after  = $expected_start + strlen( $declaration_text );
-		$candidate_style = substr( $this->style, 0, $insert_at ) . $separator . $declaration_text . substr( $this->style, $insert_at );
+		$candidate_style = substr( $this->style, 0, $insert_at ) . $eof_repair . $separator . $declaration_text . substr( $this->style, $insert_at );
 		$candidate       = new self( $candidate_style );
 		$candidate->ensure_parsed();
 
@@ -919,7 +1279,16 @@ class WP_HTML_Style_Attribute_Processor {
 
 		foreach ( $candidate->declarations as $declaration ) {
 			if ( $expected_start === $declaration['start'] && $expected_after === $declaration['after'] ) {
-				return true;
+				$parsed_value = trim(
+					substr( $candidate_style, $declaration['value_start'], $declaration['value_end'] - $declaration['value_start'] ),
+					self::WHITESPACE
+				);
+
+				return (
+					$expected_name === $declaration['name'] &&
+					$expected_value === $parsed_value &&
+					$expected_important === $declaration['important']
+				);
 			}
 		}
 
@@ -1025,6 +1394,14 @@ class WP_HTML_Style_Attribute_Processor {
 	 * @return bool Whether the property name is valid.
 	 */
 	private function is_valid_property_name( string $property_name ): bool {
+		if (
+			'' === $property_name ||
+			false !== strpos( $property_name, '\\' ) ||
+			'--' === $property_name
+		) {
+			return false;
+		}
+
 		$processor = WP_CSS_Token_Processor::create( $property_name );
 		if ( null === $processor || ! $processor->next_token() ) {
 			return false;
@@ -1068,6 +1445,10 @@ class WP_HTML_Style_Attribute_Processor {
 	 * @return bool Whether the value is valid.
 	 */
 	private function is_valid_declaration_value( string $value ): bool {
+		if ( '' === trim( $value, self::WHITESPACE ) ) {
+			return false;
+		}
+
 		$sentinel_property = '--wp-style-attribute-processor-sentinel';
 		$processor         = WP_CSS_Token_Processor::create( $value . ';' . $sentinel_property . ':1' );
 		if ( null === $processor ) {
@@ -1135,19 +1516,24 @@ class WP_HTML_Style_Attribute_Processor {
 			return false;
 		}
 
-		$top_level_count = count( $top_level_tokens );
-		if ( $top_level_count < 2 ) {
-			return true;
+		if ( empty( $top_level_tokens ) ) {
+			return false;
 		}
 
-		$last_value_token  = $top_level_tokens[ $top_level_count - 1 ];
-		$before_last_token = $top_level_tokens[ $top_level_count - 2 ];
+		for ( $i = 1; $i < count( $top_level_tokens ); $i++ ) {
+			$token        = $top_level_tokens[ $i ];
+			$before_token = $top_level_tokens[ $i - 1 ];
 
-		return ! (
-			WP_CSS_Token_Processor::TOKEN_IDENT === $last_value_token['type'] &&
-			0 === strcasecmp( 'important', (string) $last_value_token['value'] ) &&
-			WP_CSS_Token_Processor::TOKEN_DELIM === $before_last_token['type'] &&
-			'!' === $before_last_token['value']
-		);
+			if (
+				WP_CSS_Token_Processor::TOKEN_IDENT === $token['type'] &&
+				0 === strcasecmp( 'important', (string) $token['value'] ) &&
+				WP_CSS_Token_Processor::TOKEN_DELIM === $before_token['type'] &&
+				'!' === $before_token['value']
+			) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-style-attribute-processor.php
@@ -74,9 +74,15 @@ class WP_HTML_Style_Attribute_Processor {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $style Decoded style attribute value.
+	 * @param string|bool|null $style Decoded style attribute value.
 	 */
-	public function __construct( string $style ) {
+	public function __construct( $style = '' ) {
+		if ( null === $style || true === $style ) {
+			$style = '';
+		} elseif ( ! is_string( $style ) ) {
+			$style = '';
+		}
+
 		$this->style = $style;
 		$this->parse();
 	}
@@ -323,12 +329,6 @@ class WP_HTML_Style_Attribute_Processor {
 
 			if ( WP_CSS_Token_Processor::TOKEN_AT_KEYWORD === $this->tokens[ $index ]['type'] ) {
 				list( $index, $previous_item_ends_at ) = $this->consume_at_rule( $index );
-				continue;
-			}
-
-			if ( WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE === $this->tokens[ $index ]['type'] ) {
-				$previous_item_ends_at = $this->tokens[ $index ]['end'];
-				++$index;
 				continue;
 			}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -3062,7 +3062,10 @@ function _safecss_validate_value( $css, $tokens, $url_allowed, $gradient_allowed
 
 	/*
 	 * Hard pass: every url construct, at any nesting depth and for any
-	 * property, must carry a non-empty value with an allowed protocol.
+	 * property, must carry a non-empty value with an allowed protocol. This
+	 * also reaches identifiable url payloads inside malformed constructs
+	 * (a bad-url-token, or a malformed `url(` function), so a bad protocol
+	 * cannot escape via a structurally malformed shape.
 	 */
 	for ( $i = 0; $i < $count; $i++ ) {
 		$token = $tokens[ $i ];
@@ -3070,6 +3073,19 @@ function _safecss_validate_value( $css, $tokens, $url_allowed, $gradient_allowed
 
 		if ( WP_CSS_Token_Processor::TOKEN_URL === $token['type'] ) {
 			$url = trim( (string) $token['value'] );
+		} elseif ( WP_CSS_Token_Processor::TOKEN_BAD_URL === $token['type'] ) {
+			$raw       = substr( $css, $token['start'], $token['length'] );
+			$paren_pos = strpos( $raw, '(' );
+			if ( false !== $paren_pos ) {
+				$raw = substr( $raw, $paren_pos + 1 );
+			}
+			if ( ')' === substr( $raw, -1 ) ) {
+				$raw = substr( $raw, 0, -1 );
+			}
+			$raw = trim( $raw );
+			if ( '' !== $raw && wp_kses_bad_protocol( $raw, $allowed_protocols ) !== $raw ) {
+				return null;
+			}
 		} elseif (
 			WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] &&
 			0 === strcasecmp( (string) $token['value'], 'url' )
@@ -3077,6 +3093,23 @@ function _safecss_validate_value( $css, $tokens, $url_allowed, $gradient_allowed
 			$quoted = _safecss_parse_quoted_url( $tokens, $i );
 			if ( null !== $quoted ) {
 				$url = trim( (string) $tokens[ $quoted['string_index'] ]['value'] );
+			} else {
+				$j = $i + 1;
+				while (
+					$j < $count &&
+					(
+						WP_CSS_Token_Processor::TOKEN_WHITESPACE === $tokens[ $j ]['type'] ||
+						WP_CSS_Token_Processor::TOKEN_COMMENT === $tokens[ $j ]['type']
+					)
+				) {
+					++$j;
+				}
+				if ( $j < $count && WP_CSS_Token_Processor::TOKEN_STRING === $tokens[ $j ]['type'] ) {
+					$payload = trim( (string) $tokens[ $j ]['value'] );
+					if ( '' === $payload || wp_kses_bad_protocol( $payload, $allowed_protocols ) !== $payload ) {
+						return null;
+					}
+				}
 			}
 		}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2554,6 +2554,9 @@ function kses_init() {
  * @since 6.6.0 Added support for `grid-column`, `grid-row`, and `container-type`.
  * @since 6.9.0 Added support for `white-space`.
  * @since 7.1.0 Extended gradient support to allow any single-level nested function.
+ * @since {WP_VERSION} Re-implemented on top of WP_CSS_Token_Processor. Declarations
+ *                     are discovered per CSS declaration-list semantics and url()
+ *                     values are protocol-checked at any nesting depth.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
@@ -2568,9 +2571,6 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 	$css = str_replace( array( "\n", "\r", "\t" ), '', $css );
 
 	$allowed_protocols = wp_allowed_protocols();
-
-	/** @todo Parse enough CSS to split rules without breaking on things like quoted strings. */
-	$css_array = explode( ';', trim( $css ) );
 
 	/**
 	 * Filters the list of allowed CSS attributes.
@@ -2837,126 +2837,539 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 		return $css;
 	}
 
-	$css = '';
-	foreach ( $css_array as $css_item ) {
-		if ( '' === $css_item ) {
+	$tokens       = _safecss_tokenize( $css );
+	$declarations = _safecss_split_declarations( $tokens );
+
+	$filtered_css = '';
+	foreach ( $declarations as $declaration_tokens ) {
+		$declaration = _safecss_process_declaration(
+			$css,
+			$declaration_tokens,
+			$allowed_attr,
+			$css_url_data_types,
+			$css_gradient_data_types,
+			$allowed_protocols
+		);
+
+		if ( '' === $declaration ) {
 			continue;
 		}
 
-		$css_item        = trim( $css_item );
-		$css_test_string = $css_item;
-		$found           = false;
-		$url_attr        = false;
-		$gradient_attr   = false;
-		$is_custom_var   = false;
+		if ( '' !== $filtered_css ) {
+			$filtered_css .= ';';
+		}
+		$filtered_css .= $declaration;
+	}
 
-		if ( ! str_contains( $css_item, ':' ) ) {
-			$found = true;
-		} else {
-			$parts        = explode( ':', $css_item, 2 );
-			$css_selector = trim( $parts[0] );
+	return $filtered_css;
+}
 
-			// Allow assigning values to CSS variables.
-			if ( in_array( '--*', $allowed_attr, true ) && preg_match( '/^--[a-zA-Z0-9-_]+$/', $css_selector ) ) {
-				$allowed_attr[] = $css_selector;
-				$is_custom_var  = true;
-			}
+/**
+ * Tokenizes a CSS declaration list into an array of token records.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param string $css Preprocessed CSS text.
+ * @return array[] Token records with 'type', 'start', 'length', and 'value' keys.
+ */
+function _safecss_tokenize( $css ) {
+	$tokens    = array();
+	$processor = WP_CSS_Token_Processor::create( $css );
+	if ( null === $processor ) {
+		return $tokens;
+	}
 
-			if ( in_array( $css_selector, $allowed_attr, true ) ) {
-				$found         = true;
-				$url_attr      = in_array( $css_selector, $css_url_data_types, true );
-				$gradient_attr = in_array( $css_selector, $css_gradient_data_types, true );
-			}
+	while ( $processor->next_token() ) {
+		$tokens[] = array(
+			'type'   => $processor->get_token_type(),
+			'start'  => $processor->get_token_start(),
+			'length' => $processor->get_token_length(),
+			'value'  => $processor->get_token_value(),
+		);
+	}
 
-			if ( $is_custom_var ) {
-				$css_value     = trim( $parts[1] );
-				$url_attr      = str_starts_with( $css_value, 'url(' );
-				$gradient_attr = str_contains( $css_value, '-gradient(' );
-			}
+	return $tokens;
+}
+
+/**
+ * Splits a token stream into declarations at top-level semicolons.
+ *
+ * Semicolons nested inside functions, parentheses, brackets, or braces do
+ * not split; semicolons inside strings, urls, and comments are part of those
+ * tokens and never appear as semicolon tokens.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param array[] $tokens Token records from _safecss_tokenize().
+ * @return array[] Array of declarations, each an array of token records.
+ */
+function _safecss_split_declarations( $tokens ) {
+	$declarations = array();
+	$current      = array();
+	$depth        = 0;
+
+	foreach ( $tokens as $token ) {
+		$type = $token['type'];
+
+		if ( 0 === $depth && WP_CSS_Token_Processor::TOKEN_SEMICOLON === $type ) {
+			$declarations[] = $current;
+			$current        = array();
+			continue;
 		}
 
-		if ( $found && $url_attr ) {
-			// Simplified: matches the sequence `url(*)`.
-			preg_match_all( '/url\([^)]+\)/', $parts[1], $url_matches );
-
-			foreach ( $url_matches[0] as $url_match ) {
-				// Clean up the URL from each of the matches above.
-				preg_match( '/^url\(\s*([\'\"]?)(.*)(\g1)\s*\)$/', $url_match, $url_pieces );
-
-				if ( empty( $url_pieces[2] ) ) {
-					$found = false;
-					break;
-				}
-
-				$url = trim( $url_pieces[2] );
-
-				if ( empty( $url ) || wp_kses_bad_protocol( $url, $allowed_protocols ) !== $url ) {
-					$found = false;
-					break;
-				} else {
-					// Remove the whole `url(*)` bit that was matched above from the CSS.
-					$css_test_string = str_replace( $url_match, '', $css_test_string );
-				}
-			}
+		if (
+			WP_CSS_Token_Processor::TOKEN_FUNCTION === $type ||
+			WP_CSS_Token_Processor::TOKEN_LEFT_PAREN === $type ||
+			WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET === $type ||
+			WP_CSS_Token_Processor::TOKEN_LEFT_BRACE === $type
+		) {
+			++$depth;
+		} elseif (
+			$depth > 0 &&
+			(
+				WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN === $type ||
+				WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET === $type ||
+				WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE === $type
+			)
+		) {
+			--$depth;
 		}
 
-		if ( $found && $gradient_attr ) {
-			/*
-			 * Match every `*-gradient()` in the value, allowing one level of nested functions
-			 * (e.g. rgb(), hsl(), var()). Matching each occurrence, rather than requiring the
-			 * whole value to be a single gradient, lets a gradient combine with a url() image.
-			 */
-			preg_match_all( '/(?:repeating-)?(?:linear|radial|conic)-gradient\((?:[^()]|\([^()]*\))*\)/', $css_test_string, $gradient_matches );
+		$current[] = $token;
+	}
 
-			foreach ( $gradient_matches[0] as $gradient_match ) {
-				// Remove each `gradient()` bit that was matched above from the CSS.
-				$css_test_string = str_replace( $gradient_match, '', $css_test_string );
-			}
-		}
+	if ( ! empty( $current ) ) {
+		$declarations[] = $current;
+	}
 
-		if ( $found ) {
-			/*
-			 * Allow CSS functions like var(), calc(), etc. by removing them from the test string.
-			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
-			 */
-			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/',
-				'',
-				$css_test_string
-			);
+	return $declarations;
+}
 
-			/*
-			 * Disallow CSS containing \ ( & } = or comments, except for within url(), var(), calc(), etc.
-			 * which were removed from the test string above.
-			 */
-			$allow_css = ! preg_match( '%[\\\(&=}]|/\*%', $css_test_string );
+/**
+ * Validates a single declaration and returns its authored source when accepted.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param string   $css                     Preprocessed CSS text.
+ * @param array[]  $tokens                  The declaration's token records.
+ * @param string[] $allowed_attr            Allowed property names.
+ * @param string[] $css_url_data_types      Properties that accept url values.
+ * @param string[] $css_gradient_data_types Properties that accept gradient values.
+ * @param string[] $allowed_protocols       Allowed url protocols.
+ * @return string The trimmed declaration source, or '' when rejected.
+ */
+function _safecss_process_declaration( $css, $tokens, $allowed_attr, $css_url_data_types, $css_gradient_data_types, $allowed_protocols ) {
+	while ( ! empty( $tokens ) && WP_CSS_Token_Processor::TOKEN_WHITESPACE === $tokens[0]['type'] ) {
+		array_shift( $tokens );
+	}
+	while ( ! empty( $tokens ) && WP_CSS_Token_Processor::TOKEN_WHITESPACE === end( $tokens )['type'] ) {
+		array_pop( $tokens );
+	}
+	if ( empty( $tokens ) ) {
+		return '';
+	}
 
-			/**
-			 * Filters the check for unsafe CSS in `safecss_filter_attr`.
-			 *
-			 * Enables developers to determine whether a section of CSS should be allowed or discarded.
-			 * By default, the value will be false if the part contains \ ( & } = or comments.
-			 * Return true to allow the CSS part to be included in the output.
-			 *
-			 * @since 5.5.0
-			 *
-			 * @param bool   $allow_css       Whether the CSS in the test string is considered safe.
-			 * @param string $css_test_string The CSS string to test.
-			 */
-			$allow_css = apply_filters( 'safecss_filter_attr_allow_css', $allow_css, $css_test_string );
+	$last   = end( $tokens );
+	$start  = $tokens[0]['start'];
+	$source = substr( $css, $start, $last['start'] + $last['length'] - $start );
 
-			// Only add the CSS part if it passes the regex check.
-			if ( $allow_css ) {
-				if ( '' !== $css ) {
-					$css .= ';';
-				}
-
-				$css .= $css_item;
-			}
+	$colon_index = null;
+	foreach ( $tokens as $index => $token ) {
+		if ( WP_CSS_Token_Processor::TOKEN_COLON === $token['type'] ) {
+			$colon_index = $index;
+			break;
 		}
 	}
 
-	return $css;
+	$url_allowed      = false;
+	$gradient_allowed = false;
+
+	if ( null === $colon_index ) {
+		/*
+		 * Fragments without a colon have historically been kept when their
+		 * content validates; url and gradient constructs are not allowed.
+		 */
+		$value_tokens = $tokens;
+	} else {
+		$css_selector = trim( substr( $css, $start, $tokens[ $colon_index ]['start'] - $start ) );
+
+		if (
+			in_array( '--*', $allowed_attr, true ) &&
+			preg_match( '/^--[a-zA-Z0-9-_]+$/', $css_selector )
+		) {
+			$url_allowed      = true;
+			$gradient_allowed = true;
+		} elseif ( in_array( $css_selector, $allowed_attr, true ) ) {
+			$url_allowed      = in_array( $css_selector, $css_url_data_types, true );
+			$gradient_allowed = in_array( $css_selector, $css_gradient_data_types, true );
+		} else {
+			// Unknown property: dropped without consulting the filter.
+			return '';
+		}
+
+		$value_tokens = array_slice( $tokens, $colon_index + 1 );
+	}
+
+	$allow_css = _safecss_validate_value( $css, $value_tokens, $url_allowed, $gradient_allowed, $allowed_protocols );
+	if ( null === $allow_css ) {
+		// Hard rejection: dropped without consulting the filter.
+		return '';
+	}
+
+	/**
+	 * Filters the check for unsafe CSS in `safecss_filter_attr`.
+	 *
+	 * Enables developers to determine whether a declaration should be allowed
+	 * or discarded. By default, the value is the result of token-based
+	 * validation of the declaration's value. Return true to allow the
+	 * declaration to be included in the output.
+	 *
+	 * @since 5.5.0
+	 * @since {WP_VERSION} `$allow_css` is derived from token-based validation, and
+	 *                     `$css_test_string` is the declaration's authored source text.
+	 *
+	 * @param bool   $allow_css       Whether the CSS declaration is considered safe.
+	 * @param string $css_test_string The declaration's source text.
+	 */
+	$allow_css = apply_filters( 'safecss_filter_attr_allow_css', $allow_css, $source );
+
+	return $allow_css ? $source : '';
+}
+
+/**
+ * Validates a declaration value's token stream.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param string   $css               Preprocessed CSS text.
+ * @param array[]  $tokens            The value's token records.
+ * @param bool     $url_allowed       Whether url constructs are allowed.
+ * @param bool     $gradient_allowed  Whether gradient functions are allowed.
+ * @param string[] $allowed_protocols Allowed url protocols.
+ * @return bool|null Null for a hard rejection (bypasses the filter),
+ *                   otherwise the verdict passed to the filter.
+ */
+function _safecss_validate_value( $css, $tokens, $url_allowed, $gradient_allowed, $allowed_protocols ) {
+	$count = count( $tokens );
+
+	/*
+	 * Hard pass: every url construct, at any nesting depth and for any
+	 * property, must carry a non-empty value with an allowed protocol.
+	 */
+	for ( $i = 0; $i < $count; $i++ ) {
+		$token = $tokens[ $i ];
+		$url   = null;
+
+		if ( WP_CSS_Token_Processor::TOKEN_URL === $token['type'] ) {
+			$url = trim( (string) $token['value'] );
+		} elseif (
+			WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] &&
+			0 === strcasecmp( (string) $token['value'], 'url' )
+		) {
+			$quoted = _safecss_parse_quoted_url( $tokens, $i );
+			if ( null !== $quoted ) {
+				$url = trim( (string) $tokens[ $quoted['string_index'] ]['value'] );
+			}
+		}
+
+		if ( null !== $url && ( '' === $url || wp_kses_bad_protocol( $url, $allowed_protocols ) !== $url ) ) {
+			return null;
+		}
+	}
+
+	return _safecss_walk_value( $css, $tokens, $url_allowed, $gradient_allowed );
+}
+
+/**
+ * Walks a value's top-level tokens, enforcing the token allowlist.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param string  $css              Preprocessed CSS text.
+ * @param array[] $tokens           The value's token records.
+ * @param bool    $url_allowed      Whether url constructs are allowed.
+ * @param bool    $gradient_allowed Whether gradient functions are allowed.
+ * @return bool Whether the value is considered safe.
+ */
+function _safecss_walk_value( $css, $tokens, $url_allowed, $gradient_allowed ) {
+	$count = count( $tokens );
+	$i     = 0;
+
+	while ( $i < $count ) {
+		$token = $tokens[ $i ];
+
+		switch ( $token['type'] ) {
+			case WP_CSS_Token_Processor::TOKEN_WHITESPACE:
+			case WP_CSS_Token_Processor::TOKEN_NUMBER:
+			case WP_CSS_Token_Processor::TOKEN_PERCENTAGE:
+			case WP_CSS_Token_Processor::TOKEN_COMMA:
+			case WP_CSS_Token_Processor::TOKEN_COLON:
+			case WP_CSS_Token_Processor::TOKEN_HASH:
+			case WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET:
+			case WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET:
+				// A stray closing parenthesis has always been accepted.
+			case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+				++$i;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_IDENT:
+			case WP_CSS_Token_Processor::TOKEN_DIMENSION:
+				// CSS escapes are not allowed outside url values.
+				if ( false !== strpos( substr( $css, $token['start'], $token['length'] ), '\\' ) ) {
+					return false;
+				}
+				++$i;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_STRING:
+				$string_source = substr( $css, $token['start'], $token['length'] );
+				if ( false !== strpos( $string_source, '\\' ) ) {
+					return false;
+				}
+				// Reject strings left unclosed at the end of input.
+				if (
+					strlen( $string_source ) < 2 ||
+					$string_source[0] !== $string_source[ strlen( $string_source ) - 1 ]
+				) {
+					return false;
+				}
+				++$i;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_DELIM:
+				if ( in_array( $token['value'], array( '\\', '&', '=' ), true ) ) {
+					return false;
+				}
+				++$i;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_URL:
+				if ( ! $url_allowed ) {
+					return false;
+				}
+				// The url( name must be authored literally, without CSS escapes.
+				if ( 0 !== strncasecmp( substr( $css, $token['start'], 4 ), 'url(', 4 ) ) {
+					return false;
+				}
+				++$i;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+				// CSS escapes are not allowed in function names.
+				if ( false !== strpos( substr( $css, $token['start'], $token['length'] ), '\\' ) ) {
+					return false;
+				}
+
+				$function_name = (string) $token['value'];
+
+				if ( 0 === strcasecmp( $function_name, 'url' ) ) {
+					$quoted = _safecss_parse_quoted_url( $tokens, $i );
+					if ( null === $quoted || ! $url_allowed ) {
+						return false;
+					}
+					$i = $quoted['close_index'] + 1;
+					break;
+				}
+
+				if ( preg_match( '/^(?:repeating-)?(?:linear|radial|conic)-gradient$/', $function_name ) ) {
+					if ( ! $gradient_allowed ) {
+						return false;
+					}
+					$after = _safecss_walk_gradient( $tokens, $i, $url_allowed );
+					if ( null === $after ) {
+						return false;
+					}
+					$i = $after;
+					break;
+				}
+
+				if ( in_array( $function_name, array( 'var', 'calc', 'min', 'max', 'minmax', 'clamp', 'repeat' ), true ) ) {
+					$after = _safecss_walk_passthrough( $tokens, $i, $url_allowed );
+					if ( null === $after ) {
+						return false;
+					}
+					$i = $after;
+					break;
+				}
+
+				// Unknown function.
+				return false;
+
+			default:
+				/*
+				 * Comments, bad strings, bad urls, braces, bare parenthesis
+				 * blocks, at-keywords, CDO/CDC, and nested semicolons.
+				 */
+				return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Consumes a gradient function's contents, allowing one nested group level.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param array[] $tokens      The value's token records.
+ * @param int     $i           Index of the gradient's function token.
+ * @param bool    $url_allowed Whether url constructs are allowed.
+ * @return int|null Index just past the gradient's closing parenthesis, or
+ *                  null when the gradient is invalid or unclosed.
+ */
+function _safecss_walk_gradient( $tokens, $i, $url_allowed ) {
+	$count = count( $tokens );
+	$depth = 1;
+	++$i;
+
+	while ( $i < $count && $depth > 0 ) {
+		$token = $tokens[ $i ];
+
+		switch ( $token['type'] ) {
+			case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+			case WP_CSS_Token_Processor::TOKEN_LEFT_PAREN:
+				// Only one level of nested groups is allowed inside a gradient.
+				if ( $depth > 1 ) {
+					return null;
+				}
+				if (
+					WP_CSS_Token_Processor::TOKEN_FUNCTION === $token['type'] &&
+					0 === strcasecmp( (string) $token['value'], 'url' ) &&
+					( ! $url_allowed || null === _safecss_parse_quoted_url( $tokens, $i ) )
+				) {
+					return null;
+				}
+				++$depth;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+				--$depth;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_URL:
+				if ( 1 !== $depth || ! $url_allowed ) {
+					return null;
+				}
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_BAD_STRING:
+			case WP_CSS_Token_Processor::TOKEN_BAD_URL:
+				return null;
+		}
+
+		++$i;
+	}
+
+	return 0 === $depth ? $i : null;
+}
+
+/**
+ * Consumes an allowed passthrough function (var, calc, min, max, minmax,
+ * clamp, repeat), permissively, tracking parenthesis balance.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param array[] $tokens      The value's token records.
+ * @param int     $i           Index of the function token.
+ * @param bool    $url_allowed Whether url constructs are allowed.
+ * @return int|null Index just past the function's closing parenthesis, or
+ *                  null when the function is invalid or unclosed.
+ */
+function _safecss_walk_passthrough( $tokens, $i, $url_allowed ) {
+	$count = count( $tokens );
+	$depth = 1;
+	++$i;
+
+	while ( $i < $count && $depth > 0 ) {
+		$token = $tokens[ $i ];
+
+		switch ( $token['type'] ) {
+			case WP_CSS_Token_Processor::TOKEN_FUNCTION:
+				if (
+					0 === strcasecmp( (string) $token['value'], 'url' ) &&
+					( ! $url_allowed || null === _safecss_parse_quoted_url( $tokens, $i ) )
+				) {
+					return null;
+				}
+				++$depth;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_LEFT_PAREN:
+				++$depth;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN:
+				--$depth;
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_URL:
+				if ( ! $url_allowed ) {
+					return null;
+				}
+				break;
+
+			case WP_CSS_Token_Processor::TOKEN_BAD_STRING:
+			case WP_CSS_Token_Processor::TOKEN_BAD_URL:
+				return null;
+		}
+
+		++$i;
+	}
+
+	return 0 === $depth ? $i : null;
+}
+
+/**
+ * Parses a quoted url construct: a url( function token followed by optional
+ * whitespace, one string token, optional whitespace, and a closing paren.
+ *
+ * @since {WP_VERSION}
+ * @access private
+ * @ignore
+ *
+ * @param array[] $tokens The value's token records.
+ * @param int     $i      Index of the url( function token.
+ * @return array|null Array with 'string_index' and 'close_index' keys, or
+ *                    null when the construct is malformed.
+ */
+function _safecss_parse_quoted_url( $tokens, $i ) {
+	$count = count( $tokens );
+
+	$j = $i + 1;
+	if ( $j < $count && WP_CSS_Token_Processor::TOKEN_WHITESPACE === $tokens[ $j ]['type'] ) {
+		++$j;
+	}
+	if ( $j >= $count || WP_CSS_Token_Processor::TOKEN_STRING !== $tokens[ $j ]['type'] ) {
+		return null;
+	}
+
+	$k = $j + 1;
+	if ( $k < $count && WP_CSS_Token_Processor::TOKEN_WHITESPACE === $tokens[ $k ]['type'] ) {
+		++$k;
+	}
+	if ( $k >= $count || WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN !== $tokens[ $k ]['type'] ) {
+		return null;
+	}
+
+	return array(
+		'string_index' => $j,
+		'close_index'  => $k,
+	);
 }
 
 /**

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -279,6 +279,8 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-token.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-stack-event.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor-state.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor.php';
+require ABSPATH . WPINC . '/css-api/class-wp-css-builder.php';
+require ABSPATH . WPINC . '/css-api/class-wp-css-token-processor.php';
 require ABSPATH . WPINC . '/class-wp-block-processor.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -280,6 +280,7 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-processor-state.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor.php';
 require ABSPATH . WPINC . '/css-api/class-wp-css-builder.php';
 require ABSPATH . WPINC . '/css-api/class-wp-css-token-processor.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html-style-attribute-processor.php';
 require ABSPATH . WPINC . '/class-wp-block-processor.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';

--- a/tests/phpunit/data/css-api/css-test-cases.json
+++ b/tests/phpunit/data/css-api/css-test-cases.json
@@ -1,0 +1,4988 @@
+{
+	"tests/at-keyword/0001": {
+		"css": "@foo\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@foo",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "@foo",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0002": {
+		"css": "@--\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@--",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "@--",
+				"value": "--"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0003": {
+		"css": "@-1\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "@",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "@",
+				"value": "@"
+			},
+			{
+				"type": "number-token",
+				"raw": "-1",
+				"startIndex": 1,
+				"endIndex": 3,
+				"normalized": "-1",
+				"value": "-1",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0004": {
+		"css": "@--1\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@--1",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "@--1",
+				"value": "--1"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0005": {
+		"css": "@\\@\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@\\@",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "@@",
+				"value": "@"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0006": {
+		"css": "@_\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@_",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "@_",
+				"value": "_"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0007": {
+		"css": "@\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "@",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "@",
+				"value": "@"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0008": {
+		"css": "pvA3@\\\neBnP\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "pvA3",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "pvA3",
+				"value": "pvA3"
+			},
+			{
+				"type": "delim-token",
+				"raw": "@",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "@",
+				"value": "@"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\\",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\\",
+				"value": "\\"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "eBnP",
+				"startIndex": 7,
+				"endIndex": 11,
+				"normalized": "eBnP",
+				"value": "eBnP"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/at-keyword/0009": {
+		"css": "@aa𐀀\n",
+		"tokens": [
+			{
+				"type": "at-keyword-token",
+				"raw": "@aa𐀀",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "@aa𐀀",
+				"value": "aa𐀀"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-string/0001": {
+		"css": "\"foo\n\"\n",
+		"tokens": [
+			{
+				"type": "bad-string-token",
+				"raw": "\"foo",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "\"foo",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "bad-string-token",
+				"raw": "\"",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\"",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-string/0002": {
+		"css": "\"foo\\\n\"\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"foo\\\n\"",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "\"foo\"",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-string/0003": {
+		"css": "\"foo\r\n\"\n",
+		"tokens": [
+			{
+				"type": "bad-string-token",
+				"raw": "\"foo",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "\"foo",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\r\n",
+				"startIndex": 4,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "bad-string-token",
+				"raw": "\"",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\"",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-string/0004": {
+		"css": "\"foo\\\r\n\"\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"foo\\\r\n\"",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "\"foo\"",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-string/0005": {
+		"css": "\"aa𐀀\n",
+		"tokens": [
+			{
+				"type": "bad-string-token",
+				"raw": "\"aa𐀀",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "\"aa𐀀",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0001": {
+		"css": "url(\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(\n",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "url(\n",
+				"value": ""
+			}
+		]
+	},
+	"tests/bad-url/0002": {
+		"css": "url( a\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( a\n",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "url( a\n",
+				"value": "a"
+			}
+		]
+	},
+	"tests/bad-url/0003": {
+		"css": "url( a a\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url( a a\n",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "url( a a\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0004": {
+		"css": "url( a a)\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url( a a)",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "url( a a)",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0005": {
+		"css": "url( a a\\)\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url( a a\\)\n",
+				"startIndex": 0,
+				"endIndex": 11,
+				"normalized": "url( a a)\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0006": {
+		"css": "url( \\\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url( \\\n",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "url( \\\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0007": {
+		"css": "url(a'')\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url(a'')",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "url(a'')",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/bad-url/0008": {
+		"css": "url(a\")\n",
+		"tokens": [
+			{
+				"type": "bad-url-token",
+				"raw": "url(a\")",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "url(a\")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/colon/0001": {
+		"css": ":\n",
+		"tokens": [
+			{
+				"type": "colon-token",
+				"raw": ":",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ":",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/comma/0001": {
+		"css": ",\n",
+		"tokens": [
+			{
+				"type": "comma-token",
+				"raw": ",",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ",",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0001": {
+		"css": "/* a comment */\n",
+		"tokens": [
+			{
+				"type": "comment",
+				"raw": "/* a comment */",
+				"startIndex": 0,
+				"endIndex": 15,
+				"normalized": "/* a comment */",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 15,
+				"endIndex": 16,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0002": {
+		"css": "/* a comment ",
+		"tokens": [
+			{
+				"type": "comment",
+				"raw": "/* a comment ",
+				"startIndex": 0,
+				"endIndex": 13,
+				"normalized": "/* a comment ",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0003": {
+		"css": "a/**/b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "a",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": "comment",
+				"raw": "/**/",
+				"startIndex": 1,
+				"endIndex": 5,
+				"normalized": "/**/",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "b",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "b",
+				"value": "b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0004": {
+		"css": "/*\\*/*/\n",
+		"tokens": [
+			{
+				"type": "comment",
+				"raw": "/*\\*/",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "/**/",
+				"value": null
+			},
+			{
+				"type": "delim-token",
+				"raw": "*",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "*",
+				"value": "*"
+			},
+			{
+				"type": "delim-token",
+				"raw": "/",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "/",
+				"value": "/"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0005": {
+		"css": "/* a comment *",
+		"tokens": [
+			{
+				"type": "comment",
+				"raw": "/* a comment *",
+				"startIndex": 0,
+				"endIndex": 14,
+				"normalized": "/* a comment *",
+				"value": null
+			}
+		]
+	},
+	"tests/comment/0006": {
+		"css": "/*a𐀀*/\n",
+		"tokens": [
+			{
+				"type": "comment",
+				"raw": "/*a𐀀*/",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "/*a𐀀*/",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/digit/0001": {
+		"css": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "0",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "0",
+				"value": "0",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "1",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "1",
+				"value": "1",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "2",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "2",
+				"value": "2",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "3",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "3",
+				"value": "3",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "4",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "4",
+				"value": "4",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "5",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": "5",
+				"value": "5",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "6",
+				"startIndex": 12,
+				"endIndex": 13,
+				"normalized": "6",
+				"value": "6",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 13,
+				"endIndex": 14,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "7",
+				"startIndex": 14,
+				"endIndex": 15,
+				"normalized": "7",
+				"value": "7",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 15,
+				"endIndex": 16,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "8",
+				"startIndex": 16,
+				"endIndex": 17,
+				"normalized": "8",
+				"value": "8",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 17,
+				"endIndex": 18,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "9",
+				"startIndex": 18,
+				"endIndex": 19,
+				"normalized": "9",
+				"value": "9",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 19,
+				"endIndex": 20,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0001": {
+		"css": "10px\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10px",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "10px",
+				"value": "10",
+				"unit": "px",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0002": {
+		"css": "10\\70 x\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10\\70 x",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "10px",
+				"value": "10",
+				"unit": "px",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0003": {
+		"css": "10--custom-px\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10--custom-px",
+				"startIndex": 0,
+				"endIndex": 13,
+				"normalized": "10--custom-px",
+				"value": "10",
+				"unit": "--custom-px",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 13,
+				"endIndex": 14,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0004": {
+		"css": "10e2px\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10e2px",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "10e2px",
+				"value": "10e2",
+				"unit": "px",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0005": {
+		"css": "10E2PX\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10E2PX",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "10E2PX",
+				"value": "10E2",
+				"unit": "PX",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0006": {
+		"css": "10\\0\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10\\0\n",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "10�",
+				"value": "10",
+				"unit": "�",
+				"numberType": "integer"
+			}
+		]
+	},
+	"tests/dimension/0007": {
+		"css": "10a𐀀\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10a𐀀",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "10a𐀀",
+				"value": "10",
+				"unit": "a𐀀",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/dimension/0008": {
+		"css": "10a\u0000",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "10a\u0000",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "10a�",
+				"value": "10",
+				"unit": "a�",
+				"numberType": "integer"
+			}
+		]
+	},
+	"tests/escaped-code-point/0001": {
+		"css": "\\",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/escaped-code-point/0002": {
+		"css": "\\0",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\0",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/escaped-code-point/0003": {
+		"css": "\\\\",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\\\",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "\\",
+				"value": "\\"
+			}
+		]
+	},
+	"tests/escaped-code-point/0004": {
+		"css": "\\0a b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\0a b",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "\nb",
+				"value": "\nb"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0005": {
+		"css": "\\0ab \n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\0ab ",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "«",
+				"value": "«"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0006": {
+		"css": "\\0ab (foo)\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "\\0ab (",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "«(",
+				"value": "«"
+			},
+			{
+				"type": "ident-token",
+				"raw": "foo",
+				"startIndex": 6,
+				"endIndex": 9,
+				"normalized": "foo",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0007": {
+		"css": "\\0ab  (foo)\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\0ab ",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "«",
+				"value": "«"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "(-token",
+				"raw": "(",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "(",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "foo",
+				"startIndex": 7,
+				"endIndex": 10,
+				"normalized": "foo",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0008": {
+		"css": "\\0000ab\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\0000ab\n",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "«",
+				"value": "«"
+			}
+		]
+	},
+	"tests/escaped-code-point/0009": {
+		"css": "\\00000ab\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\00000ab",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "\nb",
+				"value": "\nb"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0010": {
+		"css": "\\110000\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\110000\n",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/escaped-code-point/0011": {
+		"css": "\\00D800\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\00D800\n",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/escaped-code-point/0012": {
+		"css": "\\00DFFF\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\00DFFF\n",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/escaped-code-point/0013": {
+		"css": "\\\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "\\",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "\\",
+				"value": "\\"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0014": {
+		"css": "\\\u0000\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\\u0000",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "�",
+				"value": "�"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0015": {
+		"css": "\\\u0000\b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\\u0000",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "�",
+				"value": "�"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\b",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\b",
+				"value": "\b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/escaped-code-point/0016": {
+		"css": "\"a\\12\r\nb\"",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"a\\12\r\nb\"",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "\"a\u0012b\"",
+				"value": "a\u0012b"
+			}
+		]
+	},
+	"tests/full-stop/0001": {
+		"css": ".\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": ".",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ".",
+				"value": "."
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/full-stop/0002": {
+		"css": ".a\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": ".",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ".",
+				"value": "."
+			},
+			{
+				"type": "ident-token",
+				"raw": "a",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/full-stop/0003": {
+		"css": ".1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": ".1",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": ".1",
+				"value": ".1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/fuzz/01a166c0-ca20-43a5-9ab0-0984e4a5362b": {
+		"css": "4waPtwEEGH\\\u0000jV3zM6hh6w30N0PC 7m8KM0HcWGOPw28Gt(r19",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "4waPtwEEGH\\\u0000jV3zM6hh6w30N0PC",
+				"startIndex": 0,
+				"endIndex": 28,
+				"normalized": "4waPtwEEGH�jV3zM6hh6w30N0PC",
+				"value": "4",
+				"unit": "waPtwEEGH�jV3zM6hh6w30N0PC",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 28,
+				"endIndex": 29,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "dimension-token",
+				"raw": "7m8KM0HcWGOPw28Gt",
+				"startIndex": 29,
+				"endIndex": 46,
+				"normalized": "7m8KM0HcWGOPw28Gt",
+				"value": "7",
+				"unit": "m8KM0HcWGOPw28Gt",
+				"numberType": "integer"
+			},
+			{
+				"type": "(-token",
+				"raw": "(",
+				"startIndex": 46,
+				"endIndex": 47,
+				"normalized": "(",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "r19",
+				"startIndex": 47,
+				"endIndex": 50,
+				"normalized": "r19",
+				"value": "r19"
+			}
+		]
+	},
+	"tests/fuzz/2abe9406-c063-4e9a-85ac-b13660671553": {
+		"css": "ak]P0A}808G\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5J\\\r\nBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"\"c34Q\"iiC0e45Da5f\"F5X3\"o(",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "ak",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "ak",
+				"value": "ak"
+			},
+			{
+				"type": "]-token",
+				"raw": "]",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "]",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "P0A",
+				"startIndex": 3,
+				"endIndex": 6,
+				"normalized": "P0A",
+				"value": "P0A"
+			},
+			{
+				"type": "}-token",
+				"raw": "}",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "}",
+				"value": null
+			},
+			{
+				"type": "dimension-token",
+				"raw": "808G",
+				"startIndex": 7,
+				"endIndex": 11,
+				"normalized": "808G",
+				"value": "808",
+				"unit": "G",
+				"numberType": "integer"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5J\\\r\nBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"",
+				"startIndex": 11,
+				"endIndex": 102,
+				"normalized": "\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5JBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"",
+				"value": "lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5JBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"c34Q\"",
+				"startIndex": 102,
+				"endIndex": 108,
+				"normalized": "\"c34Q\"",
+				"value": "c34Q"
+			},
+			{
+				"type": "ident-token",
+				"raw": "iiC0e45Da5f",
+				"startIndex": 108,
+				"endIndex": 119,
+				"normalized": "iiC0e45Da5f",
+				"value": "iiC0e45Da5f"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"F5X3\"",
+				"startIndex": 119,
+				"endIndex": 125,
+				"normalized": "\"F5X3\"",
+				"value": "F5X3"
+			},
+			{
+				"type": "function-token",
+				"raw": "o(",
+				"startIndex": 125,
+				"endIndex": 127,
+				"normalized": "o(",
+				"value": "o"
+			}
+		]
+	},
+	"tests/fuzz/4e630a47-507b-4b79-b00f-57f7dc1cc79d": {
+		"css": "\u000e7rSD6I5L1lglVRlL2X7BbEk\\3HCd\r94 \\\u0000skoW25d4%l64UUskN\"pHun\"!",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "\u000e",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "\u000e",
+				"value": "\u000e"
+			},
+			{
+				"type": "dimension-token",
+				"raw": "7rSD6I5L1lglVRlL2X7BbEk\\3HCd",
+				"startIndex": 1,
+				"endIndex": 29,
+				"normalized": "7rSD6I5L1lglVRlL2X7BbEk\u0003HCd",
+				"value": "7",
+				"unit": "rSD6I5L1lglVRlL2X7BbEk\u0003HCd",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\r",
+				"startIndex": 29,
+				"endIndex": 30,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "number-token",
+				"raw": "94",
+				"startIndex": 30,
+				"endIndex": 32,
+				"normalized": "94",
+				"value": "94",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 32,
+				"endIndex": 33,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "\\\u0000skoW25d4",
+				"startIndex": 33,
+				"endIndex": 43,
+				"normalized": "�skoW25d4",
+				"value": "�skoW25d4"
+			},
+			{
+				"type": "delim-token",
+				"raw": "%",
+				"startIndex": 43,
+				"endIndex": 44,
+				"normalized": "%",
+				"value": "%"
+			},
+			{
+				"type": "ident-token",
+				"raw": "l64UUskN",
+				"startIndex": 44,
+				"endIndex": 52,
+				"normalized": "l64UUskN",
+				"value": "l64UUskN"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"pHun\"",
+				"startIndex": 52,
+				"endIndex": 58,
+				"normalized": "\"pHun\"",
+				"value": "pHun"
+			},
+			{
+				"type": "delim-token",
+				"raw": "!",
+				"startIndex": 58,
+				"endIndex": 59,
+				"normalized": "!",
+				"value": "!"
+			}
+		]
+	},
+	"tests/fuzz/4f865903-e4dd-4a0b-83ed-e630cfa9dcca": {
+		"css": "gzO0{(p{DzQ7\u0000(a1;r1iN7w)",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "gzO0",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "gzO0",
+				"value": "gzO0"
+			},
+			{
+				"type": "{-token",
+				"raw": "{",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "{",
+				"value": null
+			},
+			{
+				"type": "(-token",
+				"raw": "(",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "(",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "p",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "p",
+				"value": "p"
+			},
+			{
+				"type": "{-token",
+				"raw": "{",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "{",
+				"value": null
+			},
+			{
+				"type": "function-token",
+				"raw": "DzQ7\u0000(",
+				"startIndex": 8,
+				"endIndex": 14,
+				"normalized": "DzQ7�(",
+				"value": "DzQ7�"
+			},
+			{
+				"type": "ident-token",
+				"raw": "a1",
+				"startIndex": 14,
+				"endIndex": 16,
+				"normalized": "a1",
+				"value": "a1"
+			},
+			{
+				"type": "semicolon-token",
+				"raw": ";",
+				"startIndex": 16,
+				"endIndex": 17,
+				"normalized": ";",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "r1iN7w",
+				"startIndex": 17,
+				"endIndex": 23,
+				"normalized": "r1iN7w",
+				"value": "r1iN7w"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 23,
+				"endIndex": 24,
+				"normalized": ")",
+				"value": null
+			}
+		]
+	},
+	"tests/fuzz/5181013c-60ab-483b-9c06-fb32c7e1e7e8": {
+		"css": "565'E{z\u0000U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1\\\r\nrey\thg7[5%rBK8RUC64Lu␌17O{E\\90873u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'vK\ndhCEs3tValX ",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "565",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "565",
+				"value": "565",
+				"numberType": "integer"
+			},
+			{
+				"type": "string-token",
+				"raw": "'E{z\u0000U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1\\\r\nrey\thg7[5%rBK8RUC64Lu␌17O{E\\90873u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'",
+				"startIndex": 3,
+				"endIndex": 263,
+				"normalized": "'E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1rey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'",
+				"value": "E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1rey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G"
+			},
+			{
+				"type": "ident-token",
+				"raw": "vK",
+				"startIndex": 263,
+				"endIndex": 265,
+				"normalized": "vK",
+				"value": "vK"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 265,
+				"endIndex": 266,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "dhCEs3tValX",
+				"startIndex": 266,
+				"endIndex": 277,
+				"normalized": "dhCEs3tValX",
+				"value": "dhCEs3tValX"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 277,
+				"endIndex": 278,
+				"normalized": " ",
+				"value": null
+			}
+		]
+	},
+	"tests/fuzz/6d07fc79-586f-4efa-a0a2-37d4dd3beb09": {
+		"css": "FWUNqr7uv8300nz\b,8lU0j6B186kh \u00009 \u000eGZafxf2GIhL9%",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "FWUNqr7uv8300nz",
+				"startIndex": 0,
+				"endIndex": 15,
+				"normalized": "FWUNqr7uv8300nz",
+				"value": "FWUNqr7uv8300nz"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\b",
+				"startIndex": 15,
+				"endIndex": 16,
+				"normalized": "\b",
+				"value": "\b"
+			},
+			{
+				"type": "comma-token",
+				"raw": ",",
+				"startIndex": 16,
+				"endIndex": 17,
+				"normalized": ",",
+				"value": null
+			},
+			{
+				"type": "dimension-token",
+				"raw": "8lU0j6B186kh",
+				"startIndex": 17,
+				"endIndex": 29,
+				"normalized": "8lU0j6B186kh",
+				"value": "8",
+				"unit": "lU0j6B186kh",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 29,
+				"endIndex": 30,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "\u00009",
+				"startIndex": 30,
+				"endIndex": 32,
+				"normalized": "�9",
+				"value": "�9"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 32,
+				"endIndex": 33,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "delim-token",
+				"raw": "\u000e",
+				"startIndex": 33,
+				"endIndex": 34,
+				"normalized": "\u000e",
+				"value": "\u000e"
+			},
+			{
+				"type": "ident-token",
+				"raw": "GZafxf2GIhL9",
+				"startIndex": 34,
+				"endIndex": 46,
+				"normalized": "GZafxf2GIhL9",
+				"value": "GZafxf2GIhL9"
+			},
+			{
+				"type": "delim-token",
+				"raw": "%",
+				"startIndex": 46,
+				"endIndex": 47,
+				"normalized": "%",
+				"value": "%"
+			}
+		]
+	},
+	"tests/fuzz/7f49c8fc-8292-4a3e-828b-b5d028a80d5f": {
+		"css": "FZ 0B120h5QUbNbmTD2K8mAD傿i+Yv9V0KS14Ng18ag'\\\r\n{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\\BgK48qgu9'jVRS䎟ROYRbe0m5508k,O0C\u001f",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "FZ",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "FZ",
+				"value": "FZ"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "dimension-token",
+				"raw": "0B120h5QUbNbmTD2K8mAD傿i",
+				"startIndex": 3,
+				"endIndex": 28,
+				"normalized": "0B120h5QUbNbmTD2K8mAD傿i",
+				"value": "0",
+				"unit": "B120h5QUbNbmTD2K8mAD傿i",
+				"numberType": "integer"
+			},
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 28,
+				"endIndex": 29,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "ident-token",
+				"raw": "Yv9V0KS14Ng18ag",
+				"startIndex": 29,
+				"endIndex": 44,
+				"normalized": "Yv9V0KS14Ng18ag",
+				"value": "Yv9V0KS14Ng18ag"
+			},
+			{
+				"type": "string-token",
+				"raw": "'\\\r\n{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\\BgK48qgu9'",
+				"startIndex": 44,
+				"endIndex": 126,
+				"normalized": "'{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9'",
+				"value": "{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9"
+			},
+			{
+				"type": "ident-token",
+				"raw": "jVRS䎟ROYRbe0m5508k",
+				"startIndex": 126,
+				"endIndex": 146,
+				"normalized": "jVRS䎟ROYRbe0m5508k",
+				"value": "jVRS䎟ROYRbe0m5508k"
+			},
+			{
+				"type": "comma-token",
+				"raw": ",",
+				"startIndex": 146,
+				"endIndex": 147,
+				"normalized": ",",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "O0C",
+				"startIndex": 147,
+				"endIndex": 150,
+				"normalized": "O0C",
+				"value": "O0C"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\u001f",
+				"startIndex": 150,
+				"endIndex": 151,
+				"normalized": "\u001f",
+				"value": "\u001f"
+			}
+		]
+	},
+	"tests/fuzz/864d7812-b82f-47c2-94e4-8402ba6ba94a": {
+		"css": "'TR(:\b5RN)_e3w<gD5iL1EO-3zZw ntX3@0<KP9}V0 3Q80{Tqp}7dkUykEm ks �(ZnXhqsp3)G4JKqbWAfx7sPRW\"zKg19p\"Gcoi22xb\"3h5WQan.I4EUmЕ1IBofxvJ73hTA2Em\bA97(qOU)1\u0000rV7P'5528LZ14)䓑gqcRX\"aiu� \"z3i74FJ3\u00004x8F-V5b1f(U\u000b bUc",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "'TR(:\b5RN)_e3w<gD5iL1EO-3zZw ntX3@0<KP9}V0 3Q80{Tqp}7dkUykEm ks �(ZnXhqsp3)G4JKqbWAfx7sPRW\"zKg19p\"Gcoi22xb\"3h5WQan.I4EUmЕ1IBofxvJ73hTA2Em\bA97(qOU)1\u0000rV7P'",
+				"startIndex": 0,
+				"endIndex": 156,
+				"normalized": "'TR(:\b5RN)_e3w<gD5iL1EO-3zZw ntX3@0<KP9}V0 3Q80{Tqp}7dkUykEm ks �(ZnXhqsp3)G4JKqbWAfx7sPRW\"zKg19p\"Gcoi22xb\"3h5WQan.I4EUmЕ1IBofxvJ73hTA2Em\bA97(qOU)1�rV7P'",
+				"value": "TR(:\b5RN)_e3w<gD5iL1EO-3zZw ntX3@0<KP9}V0 3Q80{Tqp}7dkUykEm ks �(ZnXhqsp3)G4JKqbWAfx7sPRW\"zKg19p\"Gcoi22xb\"3h5WQan.I4EUmЕ1IBofxvJ73hTA2Em\bA97(qOU)1�rV7P"
+			},
+			{
+				"type": "dimension-token",
+				"raw": "5528LZ14",
+				"startIndex": 156,
+				"endIndex": 164,
+				"normalized": "5528LZ14",
+				"value": "5528",
+				"unit": "LZ14",
+				"numberType": "integer"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 164,
+				"endIndex": 165,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "䓑gqcRX",
+				"startIndex": 165,
+				"endIndex": 173,
+				"normalized": "䓑gqcRX",
+				"value": "䓑gqcRX"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"aiu� \"",
+				"startIndex": 173,
+				"endIndex": 182,
+				"normalized": "\"aiu� \"",
+				"value": "aiu� "
+			},
+			{
+				"type": "function-token",
+				"raw": "z3i74FJ3\u00004x8F-V5b1f(",
+				"startIndex": 182,
+				"endIndex": 202,
+				"normalized": "z3i74FJ3�4x8F-V5b1f(",
+				"value": "z3i74FJ3�4x8F-V5b1f"
+			},
+			{
+				"type": "ident-token",
+				"raw": "U",
+				"startIndex": 202,
+				"endIndex": 203,
+				"normalized": "U",
+				"value": "U"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\u000b",
+				"startIndex": 203,
+				"endIndex": 204,
+				"normalized": "\u000b",
+				"value": "\u000b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 204,
+				"endIndex": 205,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "bUc",
+				"startIndex": 205,
+				"endIndex": 208,
+				"normalized": "bUc",
+				"value": "bUc"
+			}
+		]
+	},
+	"tests/fuzz/91de56d3-d1c7-41c9-93e2-4b0770e36e79": {
+		"css": "\tb6SUejoqAEDa\u000e9,kYO\\",
+		"tokens": [
+			{
+				"type": "whitespace-token",
+				"raw": "\t",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "\t",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "b6SUejoqAEDa",
+				"startIndex": 1,
+				"endIndex": 13,
+				"normalized": "b6SUejoqAEDa",
+				"value": "b6SUejoqAEDa"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\u000e",
+				"startIndex": 13,
+				"endIndex": 14,
+				"normalized": "\u000e",
+				"value": "\u000e"
+			},
+			{
+				"type": "number-token",
+				"raw": "9",
+				"startIndex": 14,
+				"endIndex": 15,
+				"normalized": "9",
+				"value": "9",
+				"numberType": "integer"
+			},
+			{
+				"type": "comma-token",
+				"raw": ",",
+				"startIndex": 15,
+				"endIndex": 16,
+				"normalized": ",",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "kYO\\",
+				"startIndex": 16,
+				"endIndex": 20,
+				"normalized": "kYO�",
+				"value": "kYO�"
+			}
+		]
+	},
+	"tests/fuzz/b69ece36-057f-4450-9423-a1661787bce6": {
+		"css": "Iv1\u0000B}1E+X9oO\u001fN3G",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "Iv1\u0000B",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "Iv1�B",
+				"value": "Iv1�B"
+			},
+			{
+				"type": "}-token",
+				"raw": "}",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "}",
+				"value": null
+			},
+			{
+				"type": "dimension-token",
+				"raw": "1E",
+				"startIndex": 9,
+				"endIndex": 11,
+				"normalized": "1E",
+				"value": "1",
+				"unit": "E",
+				"numberType": "integer"
+			},
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "ident-token",
+				"raw": "X9oO",
+				"startIndex": 12,
+				"endIndex": 16,
+				"normalized": "X9oO",
+				"value": "X9oO"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\u001f",
+				"startIndex": 16,
+				"endIndex": 17,
+				"normalized": "\u001f",
+				"value": "\u001f"
+			},
+			{
+				"type": "ident-token",
+				"raw": "N3G",
+				"startIndex": 17,
+				"endIndex": 20,
+				"normalized": "N3G",
+				"value": "N3G"
+			}
+		]
+	},
+	"tests/fuzz/ccfaf86d-7471-465b-bbc8-5b65be03e9cf": {
+		"css": "H%7Zkc0P17 m2cqKMI5Cz34YPit.2.7,oP ",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "H",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "H",
+				"value": "H"
+			},
+			{
+				"type": "delim-token",
+				"raw": "%",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "%",
+				"value": "%"
+			},
+			{
+				"type": "dimension-token",
+				"raw": "7Zkc0P17",
+				"startIndex": 2,
+				"endIndex": 10,
+				"normalized": "7Zkc0P17",
+				"value": "7",
+				"unit": "Zkc0P17",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "m2cqKMI5Cz34YPit",
+				"startIndex": 11,
+				"endIndex": 27,
+				"normalized": "m2cqKMI5Cz34YPit",
+				"value": "m2cqKMI5Cz34YPit"
+			},
+			{
+				"type": "number-token",
+				"raw": ".2",
+				"startIndex": 27,
+				"endIndex": 29,
+				"normalized": ".2",
+				"value": ".2",
+				"numberType": "number"
+			},
+			{
+				"type": "number-token",
+				"raw": ".7",
+				"startIndex": 29,
+				"endIndex": 31,
+				"normalized": ".7",
+				"value": ".7",
+				"numberType": "number"
+			},
+			{
+				"type": "comma-token",
+				"raw": ",",
+				"startIndex": 31,
+				"endIndex": 32,
+				"normalized": ",",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "oP",
+				"startIndex": 32,
+				"endIndex": 34,
+				"normalized": "oP",
+				"value": "oP"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 34,
+				"endIndex": 35,
+				"normalized": " ",
+				"value": null
+			}
+		]
+	},
+	"tests/fuzz/eb11f9d4-f8ef-4e11-88dc-2cbf7f56e537": {
+		"css": ">u)k2a76}y4\\6fb9ONI\\",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": ">",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ">",
+				"value": ">"
+			},
+			{
+				"type": "ident-token",
+				"raw": "u",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "u",
+				"value": "u"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "k2a76",
+				"startIndex": 3,
+				"endIndex": 8,
+				"normalized": "k2a76",
+				"value": "k2a76"
+			},
+			{
+				"type": "}-token",
+				"raw": "}",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "}",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "y4\\6fb9ONI\\",
+				"startIndex": 9,
+				"endIndex": 20,
+				"normalized": "y4澹ONI�",
+				"value": "y4澹ONI�"
+			}
+		]
+	},
+	"tests/hash/0001": {
+		"css": "#1\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#1",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "#1",
+				"value": "1"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0002": {
+		"css": "#-2\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#-2",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "#-2",
+				"value": "-2"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0003": {
+		"css": "#--3\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#--3",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "#--3",
+				"value": "--3"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0004": {
+		"css": "#---4\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#---4",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "#---4",
+				"value": "---4"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0005": {
+		"css": "#a\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#a",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "#a",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0006": {
+		"css": "#-b\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#-b",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "#-b",
+				"value": "-b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0007": {
+		"css": "#--c\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#--c",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "#--c",
+				"value": "--c"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0008": {
+		"css": "#---d\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#---d",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "#---d",
+				"value": "---d"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0009": {
+		"css": "#_\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#_",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "#_",
+				"value": "_"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0010": {
+		"css": "#_1\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#_1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "#_1",
+				"value": "_1"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0011": {
+		"css": "#-\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#-",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "#-",
+				"value": "-"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0012": {
+		"css": "#+\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "#",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "#",
+				"value": "#"
+			},
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0013": {
+		"css": "##\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "#",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "#",
+				"value": "#"
+			},
+			{
+				"type": "delim-token",
+				"raw": "#",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "#",
+				"value": "#"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hash/0014": {
+		"css": "#",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "#",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "#",
+				"value": "#"
+			}
+		]
+	},
+	"tests/hash/0015": {
+		"css": "#aa𐀀\n",
+		"tokens": [
+			{
+				"type": "hash-token",
+				"raw": "#aa𐀀",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "#aa𐀀",
+				"value": "aa𐀀"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0001": {
+		"css": "-\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "-",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "-",
+				"value": "-"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0002": {
+		"css": "-1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-1",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "-1",
+				"value": "-1",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0003": {
+		"css": "-.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-.1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-.1",
+				"value": "-.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0004": {
+		"css": "--1\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "--1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "--1",
+				"value": "--1"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0005": {
+		"css": "-0\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-0",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "-0",
+				"value": "-0",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/hyphen-minus/0006": {
+		"css": "-->\n",
+		"tokens": [
+			{
+				"type": "CDC-token",
+				"raw": "-->",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-->",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0001": {
+		"css": "foo\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "foo",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "foo",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0002": {
+		"css": "--\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "--",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "--",
+				"value": "--"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0003": {
+		"css": "--0\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "--0",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "--0",
+				"value": "--0"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0004": {
+		"css": "-\\\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "-",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "-",
+				"value": "-"
+			},
+			{
+				"type": "delim-token",
+				"raw": "\\",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\\",
+				"value": "\\"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0005": {
+		"css": "-\\ \n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "-\\ ",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "- ",
+				"value": "- "
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0006": {
+		"css": "--💅\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "--💅",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "--💅",
+				"value": "--💅"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0007": {
+		"css": "-§\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "-§",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-§",
+				"value": "-§"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0008": {
+		"css": "-×\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "-×",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-×",
+				"value": "-×"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident/0009": {
+		"css": "--a𐀀\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "--a𐀀",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "--a𐀀",
+				"value": "--a𐀀"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0001": {
+		"css": "url(foo)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(foo)",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "url(foo)",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0002": {
+		"css": "\\75 Rl(foo)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "\\75 Rl(foo)",
+				"startIndex": 0,
+				"endIndex": 11,
+				"normalized": "uRl(foo)",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0003": {
+		"css": "uR\\6c (foo)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "uR\\6c (foo)",
+				"startIndex": 0,
+				"endIndex": 11,
+				"normalized": "uRl(foo)",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0004": {
+		"css": "url('foo')\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "url(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "url(",
+				"value": "url"
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 4,
+				"endIndex": 9,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0005": {
+		"css": "url( 'foo')\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "url(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "url(",
+				"value": "url"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 5,
+				"endIndex": 10,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 10,
+				"endIndex": 11,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0006": {
+		"css": "url(  'foo')\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "url(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "url(",
+				"value": "url"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "  ",
+				"startIndex": 4,
+				"endIndex": 6,
+				"normalized": "  ",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 6,
+				"endIndex": 11,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 12,
+				"endIndex": 13,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0007": {
+		"css": "url(   'foo')\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "url(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "url(",
+				"value": "url"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "   ",
+				"startIndex": 4,
+				"endIndex": 7,
+				"normalized": "   ",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 7,
+				"endIndex": 12,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 12,
+				"endIndex": 13,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 13,
+				"endIndex": 14,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0008": {
+		"css": "not-url(   'foo')\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "not-url(",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "not-url(",
+				"value": "not-url"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "   ",
+				"startIndex": 8,
+				"endIndex": 11,
+				"normalized": "   ",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 11,
+				"endIndex": 16,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 16,
+				"endIndex": 17,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 17,
+				"endIndex": 18,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/ident-like/0009": {
+		"css": "url(   foo)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(   foo)",
+				"startIndex": 0,
+				"endIndex": 11,
+				"normalized": "url(   foo)",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/left-curly-bracket/0001": {
+		"css": "{\n",
+		"tokens": [
+			{
+				"type": "{-token",
+				"raw": "{",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "{",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/left-parenthesis/0001": {
+		"css": "(\n",
+		"tokens": [
+			{
+				"type": "(-token",
+				"raw": "(",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "(",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/left-square-bracket/0001": {
+		"css": "[\n",
+		"tokens": [
+			{
+				"type": "[-token",
+				"raw": "[",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "[",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/less-than/0001": {
+		"css": "<\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "<",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "<",
+				"value": "<"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/less-than/0002": {
+		"css": "<!--\n",
+		"tokens": [
+			{
+				"type": "CDO-token",
+				"raw": "<!--",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "<!--",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/less-than/0003": {
+		"css": "<--\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "<",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "<",
+				"value": "<"
+			},
+			{
+				"type": "ident-token",
+				"raw": "--",
+				"startIndex": 1,
+				"endIndex": 3,
+				"normalized": "--",
+				"value": "--"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/less-than/0004": {
+		"css": "<!-\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "<",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "<",
+				"value": "<"
+			},
+			{
+				"type": "delim-token",
+				"raw": "!",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "!",
+				"value": "!"
+			},
+			{
+				"type": "delim-token",
+				"raw": "-",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "-",
+				"value": "-"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0001": {
+		"css": "10\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "10",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "10",
+				"value": "10",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0002": {
+		"css": "+10\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+10",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "+10",
+				"value": "+10",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0003": {
+		"css": "-10\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-10",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-10",
+				"value": "-10",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0004": {
+		"css": "0\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "0",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "0",
+				"value": "0",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0005": {
+		"css": "+0\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+0",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "+0",
+				"value": "+0",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0006": {
+		"css": "-0\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-0",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "-0",
+				"value": "-0",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0007": {
+		"css": ".0\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": ".0",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": ".0",
+				"value": ".0",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0008": {
+		"css": ".1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": ".1",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": ".1",
+				"value": ".1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0009": {
+		"css": "+.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+.1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "+.1",
+				"value": "+.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0010": {
+		"css": "-.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-.1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "-.1",
+				"value": "-.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0011": {
+		"css": "1.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "1.1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "1.1",
+				"value": "1.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0012": {
+		"css": "+1.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+1.1",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "+1.1",
+				"value": "+1.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0013": {
+		"css": "-1.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-1.1",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "-1.1",
+				"value": "-1.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0014": {
+		"css": "1.1e2\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "1.1e2",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "1.1e2",
+				"value": "1.1e2",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0015": {
+		"css": "+1.1e+2\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+1.1e+2",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "+1.1e+2",
+				"value": "+1.1e+2",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0016": {
+		"css": "-1.1e-2\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-1.1e-2",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "-1.1e-2",
+				"value": "-1.1e-2",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0017": {
+		"css": "-1.1e-22\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-1.1e-22",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "-1.1e-22",
+				"value": "-1.1e-22",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0018": {
+		"css": "-1.1e-22e\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "-1.1e-22e",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "-1.1e-22e",
+				"value": "-1.1e-22",
+				"unit": "e",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0019": {
+		"css": "1e+\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "1e",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "1e",
+				"value": "1",
+				"unit": "e",
+				"numberType": "integer"
+			},
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/number/0020": {
+		"css": ".2.7\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": ".2",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": ".2",
+				"value": ".2",
+				"numberType": "number"
+			},
+			{
+				"type": "number-token",
+				"raw": ".7",
+				"startIndex": 2,
+				"endIndex": 4,
+				"normalized": ".7",
+				"value": ".7",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/numeric/0001": {
+		"css": "-123.753e-2\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "-123.753e-2",
+				"startIndex": 0,
+				"endIndex": 11,
+				"normalized": "-123.753e-2",
+				"value": "-123.753e-2",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/numeric/0002": {
+		"css": "-123.753e-2px\n",
+		"tokens": [
+			{
+				"type": "dimension-token",
+				"raw": "-123.753e-2px",
+				"startIndex": 0,
+				"endIndex": 13,
+				"normalized": "-123.753e-2px",
+				"value": "-123.753e-2",
+				"unit": "px",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 13,
+				"endIndex": 14,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/numeric/0003": {
+		"css": "-123.753e-2%\n",
+		"tokens": [
+			{
+				"type": "percentage-token",
+				"raw": "-123.753e-2%",
+				"startIndex": 0,
+				"endIndex": 12,
+				"normalized": "-123.753e-2%",
+				"value": "-123.753e-2"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 12,
+				"endIndex": 13,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/numeric/0004": {
+		"css": "1.2.3\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "1.2",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "1.2",
+				"value": "1.2",
+				"numberType": "number"
+			},
+			{
+				"type": "number-token",
+				"raw": ".3",
+				"startIndex": 3,
+				"endIndex": 5,
+				"normalized": ".3",
+				"value": ".3",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/plus/0001": {
+		"css": "+\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/plus/0002": {
+		"css": "+1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+1",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "+1",
+				"value": "+1",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/plus/0003": {
+		"css": "+.1\n",
+		"tokens": [
+			{
+				"type": "number-token",
+				"raw": "+.1",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "+.1",
+				"value": "+.1",
+				"numberType": "number"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/plus/0004": {
+		"css": "++1\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "+",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "+",
+				"value": "+"
+			},
+			{
+				"type": "number-token",
+				"raw": "+1",
+				"startIndex": 1,
+				"endIndex": 3,
+				"normalized": "+1",
+				"value": "+1",
+				"numberType": "integer"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/reverse-solidus/0001": {
+		"css": "\\\n",
+		"tokens": [
+			{
+				"type": "delim-token",
+				"raw": "\\",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "\\",
+				"value": "\\"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/reverse-solidus/0002": {
+		"css": "\\#\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\#",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "#",
+				"value": "#"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/reverse-solidus/0003": {
+		"css": "\\ \n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\ ",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": " ",
+				"value": " "
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 2,
+				"endIndex": 3,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/reverse-solidus/0004": {
+		"css": "\\61 b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\61 b",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "ab",
+				"value": "ab"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/reverse-solidus/0005": {
+		"css": "\\",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "�",
+				"value": "�"
+			}
+		]
+	},
+	"tests/right-curly-bracket/0001": {
+		"css": "}\n",
+		"tokens": [
+			{
+				"type": "}-token",
+				"raw": "}",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "}",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/right-parenthesis/0001": {
+		"css": ")\n",
+		"tokens": [
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/right-square-bracket/0001": {
+		"css": "]\n",
+		"tokens": [
+			{
+				"type": "]-token",
+				"raw": "]",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "]",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/semi-colon/0001": {
+		"css": ";\n",
+		"tokens": [
+			{
+				"type": "semicolon-token",
+				"raw": ";",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": ";",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 1,
+				"endIndex": 2,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/string/0001": {
+		"css": "\"foo\"\n'foo'\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"foo\"",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "\"foo\"",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'foo'",
+				"startIndex": 6,
+				"endIndex": 11,
+				"normalized": "'foo'",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 11,
+				"endIndex": 12,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/string/0002": {
+		"css": "\"foo",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"foo",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "\"foo",
+				"value": "foo"
+			}
+		]
+	},
+	"tests/string/0003": {
+		"css": "\"fo\no\"",
+		"tokens": [
+			{
+				"type": "bad-string-token",
+				"raw": "\"fo",
+				"startIndex": 0,
+				"endIndex": 3,
+				"normalized": "\"fo",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "o",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "o",
+				"value": "o"
+			},
+			{
+				"type": "string-token",
+				"raw": "\"",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\"",
+				"value": ""
+			}
+		]
+	},
+	"tests/string/0004": {
+		"css": "\"fo\\\no\"\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"fo\\\no\"",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "\"foo\"",
+				"value": "foo"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/string/0005": {
+		"css": "\"fo\\",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"fo\\",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "\"fo",
+				"value": "fo"
+			}
+		]
+	},
+	"tests/string/0006": {
+		"css": "\"esc\\61 ped\"\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"esc\\61 ped\"",
+				"startIndex": 0,
+				"endIndex": 12,
+				"normalized": "\"escaped\"",
+				"value": "escaped"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 12,
+				"endIndex": 13,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/string/0007": {
+		"css": "\"foo\\\"",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"foo\\\"",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "\"foo\"",
+				"value": "foo\""
+			}
+		]
+	},
+	"tests/string/0008": {
+		"css": "\"'foo'\"\n'\"foo\"'\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"'foo'\"",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "\"'foo'\"",
+				"value": "'foo'"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'\"foo\"'",
+				"startIndex": 8,
+				"endIndex": 15,
+				"normalized": "'\"foo\"'",
+				"value": "\"foo\""
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 15,
+				"endIndex": 16,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/string/0009": {
+		"css": "\"\\\"foo\\\"\"\n'\\'foo\\''\n",
+		"tokens": [
+			{
+				"type": "string-token",
+				"raw": "\"\\\"foo\\\"\"",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "\"\"foo\"\"",
+				"value": "\"foo\""
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			},
+			{
+				"type": "string-token",
+				"raw": "'\\'foo\\''",
+				"startIndex": 10,
+				"endIndex": 19,
+				"normalized": "''foo''",
+				"value": "'foo'"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 19,
+				"endIndex": 20,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0001": {
+		"css": "url(\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(\n",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "url(\n",
+				"value": ""
+			}
+		]
+	},
+	"tests/url/0002": {
+		"css": "url(a\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(a\n",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "url(a\n",
+				"value": "a"
+			}
+		]
+	},
+	"tests/url/0003": {
+		"css": "url( a\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( a\n",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "url( a\n",
+				"value": "a"
+			}
+		]
+	},
+	"tests/url/0004": {
+		"css": "url()\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url()",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "url()",
+				"value": ""
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0005": {
+		"css": "url( )\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( )",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "url( )",
+				"value": ""
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0006": {
+		"css": "url( a)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( a)",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "url( a)",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0007": {
+		"css": "url( a )\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( a )",
+				"startIndex": 0,
+				"endIndex": 8,
+				"normalized": "url( a )",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 8,
+				"endIndex": 9,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0008": {
+		"css": "url( \\) )\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url( \\) )",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "url( ) )",
+				"value": ")"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0009": {
+		"css": "url(https://https:⁄⁄www.netmeister.org@https://www.netmeister.org/https:⁄⁄www.netmeister.org⁄?https://www.netmeister.org=https://www.netmeister.org;https://www.netmeister.org#https://www.netmeister.org)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(https://https:⁄⁄www.netmeister.org@https://www.netmeister.org/https:⁄⁄www.netmeister.org⁄?https://www.netmeister.org=https://www.netmeister.org;https://www.netmeister.org#https://www.netmeister.org)",
+				"startIndex": 0,
+				"endIndex": 212,
+				"normalized": "url(https://https:⁄⁄www.netmeister.org@https://www.netmeister.org/https:⁄⁄www.netmeister.org⁄?https://www.netmeister.org=https://www.netmeister.org;https://www.netmeister.org#https://www.netmeister.org)",
+				"value": "https://https:⁄⁄www.netmeister.org@https://www.netmeister.org/https:⁄⁄www.netmeister.org⁄?https://www.netmeister.org=https://www.netmeister.org;https://www.netmeister.org#https://www.netmeister.org"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 212,
+				"endIndex": 213,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0010": {
+		"css": "url(https://www.netmeister.org/%62%6C%6F%67/%75%72%6C%73%2E%68%74%6D%6C?!@#$%25=+_\\)\\(*&^#top)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "url(https://www.netmeister.org/%62%6C%6F%67/%75%72%6C%73%2E%68%74%6D%6C?!@#$%25=+_\\)\\(*&^#top)",
+				"startIndex": 0,
+				"endIndex": 94,
+				"normalized": "url(https://www.netmeister.org/%62%6C%6F%67/%75%72%6C%73%2E%68%74%6D%6C?!@#$%25=+_)(*&^#top)",
+				"value": "https://www.netmeister.org/%62%6C%6F%67/%75%72%6C%73%2E%68%74%6D%6C?!@#$%25=+_)(*&^#top"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 94,
+				"endIndex": 95,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0011": {
+		"css": "Url(a)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "Url(a)",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "Url(a)",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0012": {
+		"css": "uRl(a)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "uRl(a)",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "uRl(a)",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0013": {
+		"css": "urL(a)\n",
+		"tokens": [
+			{
+				"type": "url-token",
+				"raw": "urL(a)",
+				"startIndex": 0,
+				"endIndex": 6,
+				"normalized": "urL(a)",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0014": {
+		"css": "uri(a)\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "uri(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "uri(",
+				"value": "uri"
+			},
+			{
+				"type": "ident-token",
+				"raw": "a",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/url/0015": {
+		"css": "uul(a)\n",
+		"tokens": [
+			{
+				"type": "function-token",
+				"raw": "uul(",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "uul(",
+				"value": "uul"
+			},
+			{
+				"type": "ident-token",
+				"raw": "a",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": ")-token",
+				"raw": ")",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": ")",
+				"value": null
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0001": {
+		"css": "\n",
+		"tokens": [
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0002": {
+		"css": " \n",
+		"tokens": [
+			{
+				"type": "whitespace-token",
+				"raw": " \n",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": " \n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0003": {
+		"css": "a  b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "a",
+				"startIndex": 0,
+				"endIndex": 1,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "  ",
+				"startIndex": 1,
+				"endIndex": 3,
+				"normalized": "  ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "b",
+				"startIndex": 3,
+				"endIndex": 4,
+				"normalized": "b",
+				"value": "b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0004": {
+		"css": "\\61 b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\61 b",
+				"startIndex": 0,
+				"endIndex": 5,
+				"normalized": "ab",
+				"value": "ab"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0005": {
+		"css": "\\000061 b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\000061 b",
+				"startIndex": 0,
+				"endIndex": 9,
+				"normalized": "ab",
+				"value": "ab"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 9,
+				"endIndex": 10,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0006": {
+		"css": "\\61  b\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "\\61 ",
+				"startIndex": 0,
+				"endIndex": 4,
+				"normalized": "a",
+				"value": "a"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": " ",
+				"startIndex": 4,
+				"endIndex": 5,
+				"normalized": " ",
+				"value": null
+			},
+			{
+				"type": "ident-token",
+				"raw": "b",
+				"startIndex": 5,
+				"endIndex": 6,
+				"normalized": "b",
+				"value": "b"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 6,
+				"endIndex": 7,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0007": {
+		"css": "\t\n",
+		"tokens": [
+			{
+				"type": "whitespace-token",
+				"raw": "\t\n",
+				"startIndex": 0,
+				"endIndex": 2,
+				"normalized": "\t\n",
+				"value": null
+			}
+		]
+	},
+	"tests/whitespace/0008": {
+		"css": "f\\ o\\\to\n",
+		"tokens": [
+			{
+				"type": "ident-token",
+				"raw": "f\\ o\\\to",
+				"startIndex": 0,
+				"endIndex": 7,
+				"normalized": "f o\to",
+				"value": "f o\to"
+			},
+			{
+				"type": "whitespace-token",
+				"raw": "\n",
+				"startIndex": 7,
+				"endIndex": 8,
+				"normalized": "\n",
+				"value": null
+			}
+		]
+	}
+}

--- a/tests/phpunit/tests/css-api/wpCssBuilder.php
+++ b/tests/phpunit/tests/css-api/wpCssBuilder.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Tests for the WP_CSS_Builder class.
+ *
+ * @group css-api
+ *
+ * @coversDefaultClass WP_CSS_Builder
+ */
+class Tests_CssApi_WpCssBuilder extends WP_UnitTestCase {
+	/**
+	 * @dataProvider data_string_escaping
+	 *
+	 * @covers ::string
+	 */
+	public function test_string_escaping( string $input, string $expected ): void {
+		$this->assertSame( $expected, WP_CSS_Builder::string( $input ) );
+
+		/**
+		 * Ensure that a single, equivalent CSS string is produced.
+		 *
+		 * CSS pre-processing normalization is applied to the input to ensure
+		 * a match can be found.
+		 *
+		 * @see https://www.w3.org/TR/css-syntax-3/#input-preprocessing
+		 */
+		$processor = WP_CSS_Token_Processor::create( WP_CSS_Builder::string( $input ) );
+		$processor->next_token();
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_STRING, $processor->get_token_type() );
+		$expected_decoded_value = strtr(
+			$input,
+			array(
+				"\r\n" => "\n",
+				"\r"   => "\n",
+				"\f"   => "\n",
+				"\0"   => '�',
+			)
+		);
+		$this->assertSame( $expected_decoded_value, $processor->get_token_value() );
+		$this->assertFalse( $processor->next_token() );
+	}
+
+	/**
+	 * Data provider for string escaping cases.
+	 *
+	 * @return array
+	 */
+	public static function data_string_escaping(): array {
+		return array(
+			// Passthrough — no escaping needed, only quoting.
+			'empty string'            => array( '', '""' ),
+			'simple ASCII'            => array( 'Arial', '"Arial"' ),
+			'spaces preserved'        => array( 'Exo 2', '"Exo 2"' ),
+			'leading/trailing spaces' => array( '  Arial  ', '"  Arial  "' ),
+			'whitespace-only'         => array( '   ', '"   "' ),
+			'numbers pass through'    => array( '12345', '"12345"' ),
+			'non-ASCII passthrough'   => array( 'café', '"café"' ),
+
+			// Backslash escaping — must happen first to prevent double-escaping.
+			'backslash'               => array( 'Back\\Slash', '"Back\5C Slash"' ),
+			'double backslash'        => array( '\\\\', '"\5C \5C "' ),
+			'backslash before quote'  => array( "a\\'b", '"a\5C \27 b"' ),
+
+			// NULL byte → U+FFFD replacement character.
+			'null byte'               => array( "a\0b", '"a�b"' ),
+
+			// Newline normalization — all variants become \A escape.
+			'LF'                      => array( "a\nb", '"a\A b"' ),
+			'CR'                      => array( "a\rb", '"a\A b"' ),
+			'CRLF as single escape'   => array( "a\r\nb", '"a\A b"' ),
+			'form feed'               => array( "a\fb", '"a\A b"' ),
+
+			// HTML-problematic characters.
+			'HTML characters < > &'   => array( 'a<b>c&d', '"a\3C b\3E c\26 d"' ),
+
+			// CSS-problematic characters.
+			'CSS syntax , ; { }'      => array( 'a,b;c{d}', '"a\2C b\3B c\7B d\7D "' ),
+			'single quote'            => array( "CSS's strings", '"CSS\27 s strings"' ),
+			'double quote'            => array( 'Say "Hi"', '"Say \22 Hi\22 "' ),
+		);
+	}
+
+	/**
+	 * Tests the example from the class docblock.
+	 *
+	 * @covers ::string
+	 */
+	public function test_docblock_example(): void {
+		$value    = 'CSS & a "<style>" tag\'s strings';
+		$expected = '"CSS \26  a \22 \3C style\3E \22  tag\27 s strings"';
+
+		$this->assertSame( $expected, WP_CSS_Builder::string( $value ) );
+	}
+
+	/**
+	 * Tests a string containing mixed newline types.
+	 *
+	 * @covers ::string
+	 */
+	public function test_mixed_newlines(): void {
+		$input    = "line1\nline2\rline3\r\nline4\fline5";
+		$expected = '"line1\A line2\A line3\A line4\A line5"';
+
+		$this->assertSame( $expected, WP_CSS_Builder::string( $input ) );
+	}
+
+	/**
+	 * Tests WP_CSS_Builder::ident() produces valid CSS ident tokens.
+	 *
+	 * @ticket TBD
+	 *
+	 * @dataProvider data_ident
+	 *
+	 * @covers ::ident
+	 */
+	public function test_ident( string $input, string $expected ): void {
+		$this->assertSame( $expected, WP_CSS_Builder::ident( $input ) );
+	}
+
+	/**
+	 * Data provider for ident() tests.
+	 */
+	public static function data_ident(): Generator {
+		// Simple idents — no escaping needed.
+		yield 'Simple alpha ident' => array( 'serif', 'serif' );
+		yield 'Hyphenated ident' => array( 'sans-serif', 'sans-serif' );
+		yield 'Underscore prefix' => array( '_foo', '_foo' );
+		yield 'Single char' => array( 'a', 'a' );
+		yield 'Custom property prefix' => array( '--custom', '--custom' );
+
+		// Invalid ident starts — must be escaped.
+		yield 'Leading digits' => array( '123', '\\31 23' );
+		yield 'Leading digit with alpha' => array( '5foo', '\\35 foo' );
+		yield 'Hyphen then digit' => array( '-5px', '-\\35 px' );
+		yield 'Leading space' => array( ' leading-space', '\\20 leading-space' );
+		yield 'Leading tab' => array( "\tleading-tab", '\\9 leading-tab' );
+
+		// Whitespace within ident.
+		yield 'Space within' => array( 'My Font', 'My\\20 Font' );
+		yield 'Multiple spaces within' => array( 'a b c', 'a\\20 b\\20 c' );
+		yield 'Tab within' => array( "has\ttab", 'has\\9 tab' );
+		yield 'Newline within' => array( "has\nnewline", 'has\\A newline' );
+
+		// Special characters.
+		yield 'Apostrophe' => array( "Font's", 'Font\\27 s' );
+		yield 'Angle brackets' => array( '<html>', '\\3C html\\3E ' );
+		yield 'Comma' => array( 'a,b', 'a\\2C b' );
+		yield 'Semicolon' => array( 'a;b', 'a\\3B b' );
+	}
+}

--- a/tests/phpunit/tests/css-api/wpCssTokenProcessor.php
+++ b/tests/phpunit/tests/css-api/wpCssTokenProcessor.php
@@ -1,0 +1,2809 @@
+<?php
+
+/**
+ * Comprehensive CSS processor tests based on the CSS Syntax Level 3 specification.
+ *
+ * @group css-api
+ */
+class Tests_CssApi_WpCssTokenProcessor extends WP_UnitTestCase {
+	/**
+	 * Tests that the processor produces the expected tokens for all test cases.
+	 *
+	 * @dataProvider corpus_provider
+	 */
+	public function test_processor_matches_spec( string $css, array $expected_tokens ): void {
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor );
+		$this->assertSame( $expected_tokens, $actual_tokens );
+	}
+
+	/**
+	 * Provides the test cases from the @rmenke/css-processor-test test corpus.
+	 *
+	 * @see https://github.com/romainmenke/css-processor-tests/
+	 * @return array
+	 */
+	public static function corpus_provider(): array {
+		return json_decode( file_get_contents( DIR_TESTDATA . '/css-api/css-test-cases.json' ), true );
+	}
+
+	/**
+	 * Collects all tokens from a CSS processor into an array.
+	 *
+	 * @param WP_CSS_Token_Processor $processor The CSS processor.
+	 * @return array Array of tokens with type, raw, startIndex, endIndex, structured.
+	 */
+	public static function collect_tokens( WP_CSS_Token_Processor $processor, $keys = null ): array {
+		$tokens = array();
+
+		while ( $processor->next_token() ) {
+			$type = $processor->get_token_type();
+
+			$byte_start = $processor->get_token_start();
+			$byte_end   = $byte_start + $processor->get_token_length();
+
+			$token = array(
+				'type'       => $type,
+				'raw'        => $processor->get_unnormalized_token(),
+				'startIndex' => $byte_start,
+				'endIndex'   => $byte_end,
+				'normalized' => $processor->get_normalized_token(),
+				'value'      => $processor->get_token_value(),
+			);
+			if ( null !== $processor->get_token_unit() ) {
+				$token['unit'] = $processor->get_token_unit();
+			}
+			if (
+				WP_CSS_Token_Processor::TOKEN_NUMBER === $type ||
+				WP_CSS_Token_Processor::TOKEN_DIMENSION === $type
+			) {
+				$token['numberType'] = $processor->get_token_type_flag();
+			}
+
+			if ( null !== $keys ) {
+				$token = array_intersect_key( $token, array_flip( $keys ) );
+			}
+
+			$tokens[] = $token;
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Tests that backslash-newline in a string token contributes nothing to the value.
+	 *
+	 * @ticket 62653
+	 * @dataProvider data_string_backslash_newline
+	 */
+	public function test_string_backslash_newline( string $css, string $expected_value ): void {
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( $expected_value, $processor->get_token_value() );
+	}
+
+	/**
+	 * Data provider for test_string_backslash_newline().
+	 *
+	 * @return array[]
+	 */
+	public static function data_string_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "'str\\\ning'", 'string' ),
+			'backslash-FF'   => array( "'str\\\fing'", 'string' ),
+			'backslash-CR'   => array( "'str\\\ring'", 'string' ),
+			'backslash-CRLF' => array( "'str\\\r\ning'", 'string' ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in a string token contributes nothing to the value.
+	 *
+	 * @ticket 62653
+	 */
+	public function test_string_backslash_eof(): void {
+		$processor = WP_CSS_Token_Processor::create( "'string\\" );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( 'string', $processor->get_token_value() );
+	}
+
+	/**
+	 * Tests that backslash-newline in an unquoted URL produces a bad-url token.
+	 *
+	 * @ticket 62653
+	 * @dataProvider data_url_backslash_newline
+	 */
+	public function test_url_backslash_newline( string $css ): void {
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_BAD_URL, $processor->get_token_type() );
+	}
+
+	/**
+	 * Data provider for test_url_backslash_newline().
+	 *
+	 * @return array[]
+	 */
+	public static function data_url_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "url(ab\\\ncd)" ),
+			'backslash-FF'   => array( "url(ab\\\fcd)" ),
+			'backslash-CR'   => array( "url(ab\\\rcd)" ),
+			'backslash-CRLF' => array( "url(ab\\\r\ncd)" ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in an unquoted URL produces U+FFFD in the value.
+	 *
+	 * @ticket 62653
+	 */
+	public function test_url_backslash_eof(): void {
+		$processor = WP_CSS_Token_Processor::create( 'url(string\\' );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_URL, $processor->get_token_type() );
+		$this->assertSame( "string\u{FFFD}", $processor->get_token_value() );
+	}
+
+	/**
+	 * Tests that backslash-newline stops an ident sequence.
+	 *
+	 * @ticket 62653
+	 * @dataProvider data_ident_backslash_newline
+	 */
+	public function test_ident_backslash_newline( string $css ): void {
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_IDENT, $processor->get_token_type() );
+		$this->assertSame( 'abc', $processor->get_token_value() );
+	}
+
+	/**
+	 * Data provider for test_ident_backslash_newline().
+	 *
+	 * @return array[]
+	 */
+	public static function data_ident_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "abc\\\n" ),
+			'backslash-FF'   => array( "abc\\\f" ),
+			'backslash-CR'   => array( "abc\\\r" ),
+			'backslash-CRLF' => array( "abc\\\r\n" ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in an ident produces U+FFFD in the value.
+	 *
+	 * @ticket 62653
+	 */
+	public function test_ident_backslash_eof(): void {
+		$processor = WP_CSS_Token_Processor::create( 'abc\\' );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_IDENT, $processor->get_token_type() );
+		$this->assertSame( "abc\u{FFFD}", $processor->get_token_value() );
+	}
+
+	/**
+	 * Bad string tokens have no associated value.
+	 *
+	 * @ticket 62653
+	 */
+	public function test_bad_string_token_value_is_null(): void {
+		$processor = WP_CSS_Token_Processor::create( "'str\ning'" );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_BAD_STRING, $processor->get_token_type() );
+		$this->assertNull( $processor->get_token_value() );
+	}
+
+	/**
+	 * Tests that hash tokens expose the proper type flag.
+	 *
+	 * @ticket 62653
+	 * @dataProvider data_hash_tokens_expose_type_flags
+	 */
+	public function test_hash_tokens_expose_type_flags( string $css, array $expected_tokens ): void {
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		foreach ( $expected_tokens as $expected_token ) {
+			$this->assertTrue( $processor->next_token() );
+			$this->assertSame( $expected_token['type'], $processor->get_token_type() );
+			$this->assertSame( $expected_token['raw'], $processor->get_unnormalized_token() );
+			$this->assertSame( $expected_token['type_flag'], $processor->get_token_type_flag() );
+		}
+
+		$this->assertFalse( $processor->next_token() );
+		$this->assertNull( $processor->get_token_type_flag() );
+	}
+
+	/**
+	 * Data provider for test_hash_tokens_expose_type_flags().
+	 *
+	 * @return array[]
+	 */
+	public static function data_hash_tokens_expose_type_flags(): array {
+		return array(
+			'id hash'                           => array(
+				'#id',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#id',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'unrestricted hash starting digit'  => array(
+				'#1id',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#1id',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_UNRESTRICTED,
+					),
+				),
+			),
+			'id hash starting hyphen ident'     => array(
+				'#-id',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#-id',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'unrestricted hash starting hyphen' => array(
+				'#-1id',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#-1id',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_UNRESTRICTED,
+					),
+				),
+			),
+			'id hash starting escape'           => array(
+				'#\\@special',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#\\@special',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'hash delimiter has no type flag'   => array(
+				'#',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_DELIM,
+						'raw'       => '#',
+						'type_flag' => null,
+					),
+				),
+			),
+			'following token clears type flag'  => array(
+				'#id .',
+				array(
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_HASH,
+						'raw'       => '#id',
+						'type_flag' => WP_CSS_Token_Processor::HASH_TOKEN_ID,
+					),
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+						'raw'       => ' ',
+						'type_flag' => null,
+					),
+					array(
+						'type'      => WP_CSS_Token_Processor::TOKEN_DELIM,
+						'raw'       => '.',
+						'type_flag' => null,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests token type flags for numeric and non-numeric tokens.
+	 *
+	 * @dataProvider data_token_type_flag
+	 */
+	public function test_token_type_flag( string $css, ?string $expected_type ): void {
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( $expected_type, $processor->get_token_type_flag() );
+	}
+
+	/**
+	 * Data provider for test_token_type_flag().
+	 *
+	 * @return array[]
+	 */
+	public static function data_token_type_flag(): array {
+		return array(
+			'integer'               => array( '42', 'integer' ),
+			'positive integer'      => array( '+42', 'integer' ),
+			'negative integer'      => array( '-42', 'integer' ),
+			'zero'                  => array( '0', 'integer' ),
+			'decimal'               => array( '42.0', 'number' ),
+			'decimal with fraction' => array( '42.5', 'number' ),
+			'leading decimal point' => array( '.5', 'number' ),
+			'exponent lowercase'    => array( '1e2', 'number' ),
+			'exponent uppercase'    => array( '1E2', 'number' ),
+			'exponent with plus'    => array( '1E+2', 'number' ),
+			'exponent with minus'   => array( '1e-2', 'number' ),
+			'dimension integer'     => array( '10px', 'integer' ),
+			'dimension decimal'     => array( '10.5px', 'number' ),
+			'dimension exponent'    => array( '1e2px', 'number' ),
+			'percentage integer'    => array( '20%', null ),
+			'percentage decimal'    => array( '20.0%', null ),
+			'ident token'           => array( 'red', null ),
+			'string token'          => array( '"hello"', null ),
+		);
+	}
+
+	/**
+	 * Tests handling of non-UTF-8 byte sequences in identifiers.
+	 *
+	 * Invalid UTF-8 sequences should be replaced with U+FFFD replacement characters
+	 * during tokenization, allowing the CSS to continue processing.
+	 */
+	public function test_non_utf8_sequences_in_identifiers(): void {
+		// Invalid UTF-8 sequence 0xC0 0x80 (overlong encoding).
+		$css = ".class\xF1name";
+
+		$expected = array(
+			// .class�name (0xF1 replaced with U+FFFD).
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => "class\xF1name",
+				'normalized' => 'class�name',
+				'value'      => 'class�name',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value', 'unit' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	public function test_invalid_utf8_in_normal_segment_combined_with_escape(): void {
+		$css = ".test\xF1\\41name";
+
+		$expected = array(
+			array(
+				'type'  => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'   => '.',
+				'value' => '.',
+			),
+			array(
+				'type'  => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'   => "test\xF1\\41name",
+				'value' => "test\u{FFFD}Aname",
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	public function test_invalid_utf8_as_escaped_character(): void {
+		$css = ".a\\\xF1b";
+
+		$expected = array(
+			array(
+				'type'  => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'   => '.',
+				'value' => '.',
+			),
+			array(
+				'type'  => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'   => "a\\\xF1b",
+				'value' => "a\u{FFFD}b",
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	public function test_invalid_utf8_with_valid_prefix_in_identifiers(): void {
+		// Invalid 2-byte prefix is replaced with a single U+FFFD.
+		$css = ".test\xE2\x80name";
+
+		$expected = array(
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => "test\xE2\x80name",
+				'normalized' => 'test�name',
+				'value'      => 'test�name',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	public function test_invalid_utf8_with_two_single_byte_invalid_sequences(): void {
+		// Two distinct single byte invalid sequences are replaced with
+		// two separate U+FFFD replacement characters.
+		$css = ".test\xE2\xE2name";
+
+		$expected = array(
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => "test\xE2\xE2name",
+				'normalized' => 'test��name',
+				'value'      => 'test��name',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	/**
+	 * Legacy test to ensure basic tokenization still works.
+	 */
+	public function test_tokenize_labels_core_tokens(): void {
+		$css = <<<CSS
+@media screen and (min-width: 10px) {
+	background: url("/images/a.png");
+}
+CSS;
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_AT_KEYWORD,
+				'raw'  => '@media',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'screen',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'and',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_PAREN,
+				'raw'  => '(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'min-width',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '10px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => "\n\t",
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'background',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'url(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'  => '"/images/a.png"',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => "\n",
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of complex selectors with pseudo-classes.
+	 */
+	public function test_complex_selector_with_pseudo_classes(): void {
+		$css = 'a:hover::before, div.class#id:not(.disabled)';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'a',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'hover',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'before',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'div',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '.',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'class',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_HASH,
+				'raw'  => '#id',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'not(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '.',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'disabled',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of CSS comments.
+	 */
+	public function test_css_comments(): void {
+		$css = '/* This is a comment */ .class { color: red; /* Another comment */ }';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMENT,
+				'raw'  => '/* This is a comment */',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '.',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'class',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'red',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMENT,
+				'raw'  => '/* Another comment */',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of media queries.
+	 */
+	public function test_media_query(): void {
+		$css = '@media screen and (min-width: 768px) and (max-width: 1024px)';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_AT_KEYWORD,
+				'raw'  => '@media',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'screen',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'and',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_PAREN,
+				'raw'  => '(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'min-width',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '768px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'and',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_PAREN,
+				'raw'  => '(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'max-width',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '1024px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of keyframes animation.
+	 */
+	public function test_keyframes_animation(): void {
+		$css = '@keyframes slide-in { 0% { opacity: 0; } 100% { opacity: 1; } }';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_AT_KEYWORD,
+				'raw'  => '@keyframes',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'slide-in',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'  => '0%',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'opacity',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'  => '100%',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'opacity',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '1',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of vendor-prefixed properties.
+	 */
+	public function test_vendor_prefixed_properties(): void {
+		$css = '-webkit-transform: rotate(45deg); -moz-border-radius: 5px;';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => '-webkit-transform',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'rotate(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '45deg',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => '-moz-border-radius',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '5px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of attribute selectors.
+	 */
+	public function test_attribute_selectors(): void {
+		$css = 'input[type="text"][required], a[href^="https://"]';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'input',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET,
+				'raw'  => '[',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'type',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '=',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'  => '"text"',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET,
+				'raw'  => ']',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET,
+				'raw'  => '[',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'required',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET,
+				'raw'  => ']',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'a',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACKET,
+				'raw'  => '[',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'href',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '^',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '=',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'  => '"https://"',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACKET,
+				'raw'  => ']',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of calc() function with complex expressions.
+	 */
+	public function test_calc_function(): void {
+		$css = 'width: calc(100% - 20px * 2 + 5em);';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'width',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'calc(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'  => '100%',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '-',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '20px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '*',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '2',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '+',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '5em',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of RGB/RGBA color functions.
+	 */
+	public function test_color_functions(): void {
+		$css = 'color: rgb(255, 128, 0); background: rgba(0, 0, 0, 0.5);';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'rgb(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '255',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '128',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'background',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'rgba(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '0.5',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of CSS custom properties (variables).
+	 */
+	public function test_css_variables(): void {
+		$css = '--main-color: #ff0000; color: var(--main-color);';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => '--main-color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_HASH,
+				'raw'  => '#ff0000',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'var(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => '--main-color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of gradient functions.
+	 */
+	public function test_gradient_functions(): void {
+		$css = 'background: linear-gradient(to right, red 0%, blue 100%);';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'background',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'linear-gradient(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'to',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'right',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'red',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'  => '0%',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'blue',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'  => '100%',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of grid layout properties.
+	 */
+	public function test_grid_layout(): void {
+		$css = 'grid-template-columns: repeat(3, 1fr); gap: 10px 20px;';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'grid-template-columns',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'repeat(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_NUMBER,
+				'raw'  => '3',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '1fr',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'gap',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '10px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '20px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of URL functions with various formats.
+	 */
+	public function test_url_formats(): void {
+		$css = 'background: url("image.png"), url(\'font.woff\'), url(https://example.com/bg.jpg);';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'background',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'url(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'  => '"image.png"',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'  => 'url(',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'  => "'font.woff'",
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'  => ')',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_URL,
+				'raw'  => 'url(https://example.com/bg.jpg)',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of !important declarations.
+	 */
+	public function test_important_declarations(): void {
+		$css = 'color: red !important; margin: 0px !important;';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'red',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '!',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'important',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'margin',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'  => '0px',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '!',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'important',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of multiple selectors with combinators.
+	 */
+	public function test_complex_combinators(): void {
+		$css = 'div > p + span ~ a.link';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'div',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '>',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'p',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '+',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'span',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '~',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'a',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '.',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'link',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests tokenization of escaped characters in identifiers.
+	 */
+	public function test_escaped_identifiers(): void {
+		$css = '.class\\:name, #id\\@special { color: blue; }';
+
+		$expected = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '.',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'class\\:name',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COMMA,
+				'raw'  => ',',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_HASH,
+				'raw'  => '#id\\@special',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'  => '{',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'color',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'  => ':',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'  => 'blue',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'  => ';',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'  => ' ',
+			),
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'  => '}',
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$this->assertSame( $actual_tokens, $expected );
+	}
+
+	/**
+	 * Tests that get_normalized_token() applies CSS normalization.
+	 *
+	 * Uses a comprehensive CSS selector with rules that includes:
+	 * - CSS escapes in class names and IDs
+	 * - URLs with escape sequences
+	 * - String values with escapes and line endings
+	 * - Comments with various line ending characters
+	 * - Null bytes in identifiers
+	 * - Mixed line endings (\r\n, \r, \f) that need normalization
+	 */
+	public function test_get_normalized_token_applies_normalization(): void {
+		// Comprehensive CSS with normalization requirements.
+		$css = "/* Comment\r\nwith\flines */\r\n" .
+				".c\\6c ass.n\\61 me\r#id\\@value\r\n{\r\n" .
+				"\tbackground:\furl(path\\2f to\\2f image.png);\r\n" .
+				"\tcontent:\r\"text\\A string\";\r\n" .
+				'}';
+
+		$expected = array(
+			// Comment with \r\n and \f.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COMMENT,
+				'raw'        => "/* Comment\r\nwith\flines */",
+				'normalized' => "/* Comment\nwith\nlines */",
+				'value'      => null,
+			),
+			// Whitespace with \r\n.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r\n",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// Class selector delimiter.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			// Class name with escape (\6c = 'l'), space gets consumed by escape.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'c\\6c ass',
+				'normalized' => 'class', // Escapes decoded.
+				'value'      => 'class', // Decoded: \6c → l, space consumed.
+			),
+			// Delimiter.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			// Identifier with escape (\61 = 'a'), space gets consumed.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'n\\61 me',
+				'normalized' => 'name', // Escapes decoded.
+				'value'      => 'name', // Decoded: \61 → a, space consumed.
+			),
+			// Whitespace with \r.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// ID selector with escape.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_HASH,
+				'raw'        => '#id\\@value',
+				'normalized' => '#id@value', // Escapes decoded.
+				'value'      => 'id@value', // Decoded value.
+			),
+			// Whitespace with \r\n.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r\n",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// Opening brace.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'        => '{',
+				'normalized' => '{',
+				'value'      => null,
+			),
+			// Whitespace with \r\n and tab (consumed together).
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r\n\t",
+				'normalized' => "\n\t",
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'background',
+				'normalized' => 'background',
+				'value'      => 'background',
+			),
+			// Colon.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			// Whitespace with \f.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\f",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// URL token with escapes (entire url(...) is one token).
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_URL,
+				'raw'        => 'url(path\\2f to\\2f image.png)',
+				'normalized' => 'url(path/to/image.png)', // Escapes decoded.
+				'value'      => 'path/to/image.png', // Decoded: \2f → /, spaces consumed.
+			),
+			// Semicolon.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			// Whitespace with \r\n and tab (consumed together).
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r\n\t",
+				'normalized' => "\n\t",
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'content',
+				'normalized' => 'content',
+				'value'      => 'content',
+			),
+			// Colon.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			// Whitespace with \r.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// String with escape (\A = newline, space consumed).
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'        => '"text\\A string"',
+				'normalized' => "\"text\nstring\"", // Escapes decoded, quotes preserved.
+				'value'      => "text\nstring", // \A → \n, space consumed.
+			),
+			// Semicolon.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			// Whitespace with \r\n.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => "\r\n",
+				'normalized' => "\n",
+				'value'      => null,
+			),
+			// Closing brace.
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'        => '}',
+				'normalized' => '}',
+				'value'      => null,
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	public function test_dimension_token_value(): void {
+		$css           = '10px;15em;20%;30pt;40pc;50vw;';
+		$expected      = array(
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '10px',
+				'normalized' => '10px',
+				'value'      => '10',
+				'unit'       => 'px',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '15em',
+				'normalized' => '15em',
+				'value'      => '15',
+				'unit'       => 'em',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_PERCENTAGE,
+				'raw'        => '20%',
+				'normalized' => '20%',
+				'value'      => '20',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '30pt',
+				'normalized' => '30pt',
+				'value'      => '30',
+				'unit'       => 'pt',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '40pc',
+				'normalized' => '40pc',
+				'value'      => '40',
+				'unit'       => 'pc',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '50vw',
+				'normalized' => '50vw',
+				'value'      => '50',
+				'unit'       => 'vw',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+		);
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value', 'unit' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	/**
+	 * Tests that create() validates encoding and only accepts UTF-8.
+	 */
+	public function test_create_validates_encoding(): void {
+		// UTF-8 encoding should work (default).
+		$processor = WP_CSS_Token_Processor::create( '.class { color: red; }' );
+		$this->assertInstanceOf( WP_CSS_Token_Processor::class, $processor );
+
+		// UTF-8 encoding should work (explicit).
+		$processor = WP_CSS_Token_Processor::create( '.class { color: red; }', 'UTF-8' );
+		$this->assertInstanceOf( WP_CSS_Token_Processor::class, $processor );
+
+		// Other encodings should return null.
+		$processor = WP_CSS_Token_Processor::create( '.class { color: red; }', 'ISO-8859-1' );
+		$this->assertNull( $processor );
+
+		$processor = WP_CSS_Token_Processor::create( '.class { color: red; }', 'Windows-1252' );
+		$this->assertNull( $processor );
+	}
+
+	/**
+	 * Tests escape sequences in unusual and edge-case positions.
+	 *
+	 * Covers:
+	 * - Multiple consecutive escapes
+	 * - Escapes in function names
+	 * - Escapes in at-keywords
+	 * - Escapes in dimension units
+	 * - Null byte escapes (\0)
+	 * - Escaped special characters (@, #, !, etc.)
+	 * - Escaped whitespace that gets consumed by the escape
+	 * - Unicode escapes for various characters
+	 */
+	public function test_escape_sequences_in_unusual_places() {
+		// Complex CSS with escapes in many unusual but valid positions
+		$css = '@\\6D edia ' . // @media with \6D (m) and space consumed
+				'\\73 creen ' . // screen with \73 (s) and space consumed
+				'{' .
+				' .\\63 l\\61 ss\\5F name ' . // .class_name with escapes and spaces consumed
+				"#\\69 d\\5C 0test\x00 " . // #id\0test with null byte escape (should be preserved)
+														// AND an actual null byte (should be replaced with a U+FFFD REPLACEMENT CHARACTER)
+				'{' .
+				' c\\6F lor: ' . // color: with \6F (o) and space consumed
+				'r\\65 d ' . // red with escape
+				'\\21 important;' . // !important with escaped !
+				' w\\69 dth: ' . // width:
+				'10\\70 x;' . // 10px (dimension with escaped unit)
+				' background: ' .
+				'\\75 rl(' . // url( with escaped u
+				'"p\\61 th\\2F img\\2E png"' . // "path/img.png" with escapes
+				');' .
+				' content: "\\5C \\5C ";' . // "\\ \\" - escaped backslashes
+				' font-family: \\22 Arial\\22 ;' . // "Arial" with escaped quotes
+				' }' .
+				'}';
+
+		$expected = array(
+			// @\6D edia -> @media
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_AT_KEYWORD,
+				'raw'        => '@\\6D edia',
+				'normalized' => '@media',
+				'value'      => 'media',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// \73 creen -> screen
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => '\\73 creen',
+				'normalized' => 'screen',
+				'value'      => 'screen',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'        => '{',
+				'normalized' => '{',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// Delimiter .
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'        => '.',
+				'normalized' => '.',
+				'value'      => '.',
+			),
+			// \63 l\61 ss\5F name -> class_name
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => '\\63 l\\61 ss\\5F name',
+				'normalized' => 'class_name',
+				'value'      => 'class_name',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// #\69 d\5C 0test -> #id\0test (with encoded null byte)
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_HASH,
+				'raw'        => "#\\69 d\\5C 0test\x00",
+				'normalized' => "#id\\0test�",
+				// Ensure the value is normalized.
+				'value'      => "id\\0test�",
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_LEFT_BRACE,
+				'raw'        => '{',
+				'normalized' => '{',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// c\6F lor -> color
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'c\\6F lor',
+				'normalized' => 'color',
+				'value'      => 'color',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// r\65 d -> red
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'r\\65 d',
+				'normalized' => 'red',
+				'value'      => 'red',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// \21 important -> !important (single identifier with escaped !)
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => '\\21 important',
+				'normalized' => '!important',
+				'value'      => '!important',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// w\69 dth -> width
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'w\\69 dth',
+				'normalized' => 'width',
+				'value'      => 'width',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// 10\70 x -> 10px (dimension with escaped unit)
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_DIMENSION,
+				'raw'        => '10\\70 x',
+				'normalized' => '10px',
+				'value'      => '10',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'background',
+				'normalized' => 'background',
+				'value'      => 'background',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// \75 rl( -> url( (escaped function name)
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_FUNCTION,
+				'raw'        => '\\75 rl(',
+				'normalized' => 'url(',
+				'value'      => 'url',
+			),
+			// String with escapes: "p\61 th\2F img\2E png"
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'        => '"p\\61 th\\2F img\\2E png"',
+				'normalized' => '"path/img.png"',
+				'value'      => 'path/img.png',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_RIGHT_PAREN,
+				'raw'        => ')',
+				'normalized' => ')',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'content',
+				'normalized' => 'content',
+				'value'      => 'content',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// String with escaped backslashes: "\5C \5C " -> "\\"
+			// Each \5C sequence (with trailing space consumed) becomes one backslash
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_STRING,
+				'raw'        => '"\\5C \\5C "',
+				'normalized' => '"\\\\"',
+				'value'      => '\\\\',  // Two backslashes total
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => 'font-family',
+				'normalized' => 'font-family',
+				'value'      => 'font-family',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_COLON,
+				'raw'        => ':',
+				'normalized' => ':',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			// \22 Arial\22 -> "Arial" (escaped quotes make it an ident)
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_IDENT,
+				'raw'        => '\\22 Arial\\22 ',
+				'normalized' => '"Arial"',
+				'value'      => '"Arial"',
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_SEMICOLON,
+				'raw'        => ';',
+				'normalized' => ';',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_WHITESPACE,
+				'raw'        => ' ',
+				'normalized' => ' ',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'        => '}',
+				'normalized' => '}',
+				'value'      => null,
+			),
+			array(
+				'type'       => WP_CSS_Token_Processor::TOKEN_RIGHT_BRACE,
+				'raw'        => '}',
+				'normalized' => '}',
+				'value'      => null,
+			),
+		);
+
+		$processor     = WP_CSS_Token_Processor::create( $css );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw', 'normalized', 'value' ) );
+		$this->assertSame( $expected, $actual_tokens );
+	}
+
+	/**
+	 * Tests that set_token_value() only works on URL tokens.
+	 */
+	public function test_set_token_value_only_works_on_url_tokens(): void {
+		$css       = 'color: red; background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$this->setExpectedIncorrectUsage( 'WP_CSS_Token_Processor::set_token_value' );
+
+		while ( $processor->next_token() ) {
+			$token_type = $processor->get_token_type();
+
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $token_type ) {
+				// Should succeed on URL tokens.
+				$this->assertTrue( $processor->set_token_value( 'new.jpg' ) );
+			} else {
+				// Should fail on non-URL tokens.
+				$this->assertFalse( $processor->set_token_value( 'test' ) );
+			}
+		}
+
+		// Verify the update was applied.
+		$updated = $processor->get_updated_css();
+		$this->assertSame( 'color: red; background: url("new.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that set_token_value() properly escapes special characters in quoted URLs.
+	 */
+	public function test_set_token_value_escapes_special_characters(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				// URL with spaces, quotes, and parentheses.
+				$processor->set_token_value( 'path with spaces("special").jpg' );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		$this->assertSame( 'background: url("path with spaces(\\22 special\\22 ).jpg");', $updated );
+	}
+
+	/**
+	 * Tests that set_token_value() preserves Unicode characters in quoted URLs.
+	 */
+	public function test_set_token_value_encodes_unicode(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				// URL with Unicode characters: "测试.jpg" (Chinese characters).
+				$processor->set_token_value( '测试.jpg' );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		$this->assertSame( 'background: url("测试.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that set_token_value() preserves emoji in quoted URLs.
+	 */
+	public function test_set_token_value_handles_emoji(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				// URL with emoji: "image😀.jpg".
+				$processor->set_token_value( 'image😀.jpg' );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		$this->assertSame( 'background: url("image😀.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that multiple URL values can be updated in the same CSS.
+	 */
+	public function test_set_token_value_multiple_urls(): void {
+		$css       = 'background: url(old1.jpg); border-image: url(old2.png);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		$url_count = 0;
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				++$url_count;
+				if ( 1 === $url_count ) {
+					$processor->set_token_value( 'new1.jpg' );
+				} elseif ( 2 === $url_count ) {
+					$processor->set_token_value( 'new2.png' );
+				}
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		// Verify both URLs were updated.
+		$this->assertSame( 'background: url("new1.jpg"); border-image: url("new2.png");', $updated );
+	}
+
+	/**
+	 * Tests that newlines are properly escaped in quoted URLs.
+	 */
+	public function test_set_token_value_escapes_control_characters(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				// URL with newlines and carriage returns.
+				$processor->set_token_value( "path\nwith\rnewlines\ftest.jpg" );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		$this->assertSame( 'background: url("path\\A with\\A newlines\\A test.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that backslashes are properly escaped in quoted URLs.
+	 */
+	public function test_set_token_value_escapes_backslashes(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				$processor->set_token_value( 'path\\with\\backslashes.jpg' );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		// Verify backslashes are escaped as \\.
+		$this->assertSame( 'background: url("path\\5C with\\5C backslashes.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that get_updated_css() returns original CSS when no changes are made.
+	 */
+	public function test_get_updated_css_returns_original_when_unchanged(): void {
+		$css       = 'background: url(image.jpg); color: red;';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		// Iterate through tokens without making changes.
+		while ( $processor->next_token() ) {
+			// Do nothing.
+		}
+
+		$updated = $processor->get_updated_css();
+
+		// Should return original CSS.
+		$this->assertSame( $css, $updated );
+	}
+
+	/**
+	 * Tests that safe ASCII characters are preserved in quoted URLs.
+	 */
+	public function test_set_token_value_preserves_safe_characters(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				// URL with safe characters: letters, digits, hyphens, underscores, dots, slashes.
+				$processor->set_token_value( 'path/to/my-image_2024.jpg' );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		// Verify safe characters are preserved as-is in quoted URL.
+		$this->assertSame( 'background: url("path/to/my-image_2024.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that invalid UTF-8 sequences are replaced in quoted URLs.
+	 */
+	public function test_set_token_with_invalid_utf8_sequence(): void {
+		$css       = 'background: url(old.jpg);';
+		$processor = WP_CSS_Token_Processor::create( $css );
+
+		while ( $processor->next_token() ) {
+			if ( WP_CSS_Token_Processor::TOKEN_URL === $processor->get_token_type() ) {
+				$processor->set_token_value( "\xC0.jpg" );
+			}
+		}
+
+		$updated = $processor->get_updated_css();
+
+		$this->assertSame( 'background: url("�.jpg");', $updated );
+	}
+
+	/**
+	 * Tests that decode_range() respects the token's length boundary.
+	 *
+	 * The escape sequence \41 (= "A") triggers the slow path. The CSS after
+	 * the closing quote must not appear in the token value.
+	 */
+	public function test_decode_range_respects_length_boundary(): void {
+		$processor = WP_CSS_Token_Processor::create( '"hello\\41 world"; color: red;' );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( 'helloAworld', $processor->get_token_value() );
+		$this->assertSame( '"helloAworld"', $processor->get_normalized_token() );
+	}
+
+	/**
+	 * Tests that decode_escape_at() consumes at most six hex digits.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point
+	 */
+	public function test_decode_escape_at_hex_limit_is_six_digits(): void {
+		$processor = WP_CSS_Token_Processor::create( '"\\0000411rest"' );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( WP_CSS_Token_Processor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( 'A1rest', $processor->get_token_value() );
+	}
+
+	/**
+	 * Test bounds check when consuming and ident start token.
+	 */
+	public function test_ident_start_codepoint_bounds_check(): void {
+		$processor       = WP_CSS_Token_Processor::create( '-' );
+		$actual_tokens   = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$expected_tokens = array(
+			array(
+				'type' => WP_CSS_Token_Processor::TOKEN_DELIM,
+				'raw'  => '-',
+			),
+		);
+		$this->assertSame( $expected_tokens, $actual_tokens );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -13,73 +13,96 @@
  */
 class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	/**
-	 * @covers ::__construct
-	 * @covers ::next_declaration
+	 * @covers ::create
 	 * @covers ::get_updated_style
-	 *
-	 * @dataProvider data_html_style_attribute_values
-	 *
-	 * @param string      $html           HTML containing a first div.
-	 * @param string      $expected_style Expected normalized style input.
-	 * @param string|null $property_name  Expected first property name.
 	 */
-	public function test_constructor_accepts_html_tag_processor_style_attribute_values( string $html, string $expected_style, ?string $property_name ) {
-		$tags = new WP_HTML_Tag_Processor( $html );
-		$this->assertTrue( $tags->next_tag( 'div' ) );
+	public function test_create_accepts_decoded_css_text_strings() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red' );
 
-		$processor = new WP_HTML_Style_Attribute_Processor( $tags->get_attribute( 'style' ) );
+		$this->assertSame( 'color: red', $processor->get_updated_style() );
+	}
 
-		$this->assertSame( $expected_style, $processor->get_updated_style() );
+	/**
+	 * @covers ::create
+	 *
+	 * @dataProvider data_non_string_style_attribute_values
+	 *
+	 * @param mixed $style_attribute_value Non-string style attribute value.
+	 */
+	public function test_create_rejects_non_string_style_attribute_values( $style_attribute_value ) {
+		$this->expectException( TypeError::class );
 
-		if ( null === $property_name ) {
-			$this->assertFalse( $processor->next_declaration() );
-		} else {
-			$this->assertTrue( $processor->next_declaration() );
-			$this->assertSame( $property_name, $processor->get_property_name() );
-		}
+		WP_HTML_Style_Attribute_Processor::create( $style_attribute_value );
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function test_constructor_is_not_public() {
+		$reflection  = new ReflectionClass( WP_HTML_Style_Attribute_Processor::class );
+		$constructor = $reflection->getConstructor();
+
+		$this->assertNotNull( $constructor );
+		$this->assertFalse( $constructor->isPublic() );
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function test_raw_value_getter_is_not_public_api() {
+		$this->assertFalse( method_exists( WP_HTML_Style_Attribute_Processor::class, 'get_value' ) );
+		$this->assertFalse( method_exists( WP_HTML_Style_Attribute_Processor::class, 'get_raw_value' ) );
 	}
 
 	/**
 	 * @covers ::next_declaration
 	 * @covers ::get_property_name
-	 * @covers ::get_value
+	 * @covers ::is_important
 	 */
 	public function test_next_declaration_reads_properties_in_order_and_preserves_duplicates() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: color(display-p3 1 0 0); background: blue' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'COLOR: red; color: blue !important; background: white' );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'color', $processor->get_property_name() );
-		$this->assertSame( 'red', $processor->get_value() );
+		$this->assertFalse( $processor->is_important() );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'color', $processor->get_property_name() );
-		$this->assertSame( 'color(display-p3 1 0 0)', $processor->get_value() );
+		$this->assertTrue( $processor->is_important() );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'blue', $processor->get_value() );
 
 		$this->assertFalse( $processor->next_declaration() );
+		$this->assertNull( $processor->get_property_name() );
+		$this->assertNull( $processor->is_important() );
 	}
 
 	/**
 	 * @covers ::next_declaration
+	 * @covers ::get_property_name
 	 */
 	public function test_next_declaration_query_visits_matching_duplicate_properties() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white; COLOR: blue;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; background: white; COLOR: blue;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
-		$this->assertSame( 'red', $processor->get_value() );
+		$this->assertSame( 'color', $processor->get_property_name() );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
-		$this->assertSame( 'blue', $processor->get_value() );
+		$this->assertSame( 'color', $processor->get_property_name() );
 
 		$this->assertFalse( $processor->next_declaration( 'color' ) );
+	}
 
-		$processor = new WP_HTML_Style_Attribute_Processor( '--Tone: warm; --tone: cool;' );
+	/**
+	 * @covers ::next_declaration
+	 * @covers ::get_property_name
+	 */
+	public function test_custom_property_queries_match_exact_decoded_casing() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( '--Tone: warm; --tone: cool;' );
 
 		$this->assertTrue( $processor->next_declaration( '--tone' ) );
-		$this->assertSame( 'cool', $processor->get_value() );
+		$this->assertSame( '--tone', $processor->get_property_name() );
 
 		$this->assertFalse( $processor->next_declaration( '--tone' ) );
 	}
@@ -88,31 +111,25 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::next_declaration
 	 */
 	public function test_next_declaration_accepts_named_property_name_argument() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; background: white;' );
 
-		$this->assertTrue( $processor->next_declaration( property_name: 'background' ) );
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'white', $processor->get_value() );
 	}
 
 	/**
 	 * @covers ::is_important
-	 * @covers ::get_value
+	 *
+	 * @dataProvider data_important_priority_syntax
+	 *
+	 * @param string $style     Style attribute value.
+	 * @param bool   $important Expected importance.
 	 */
-	public function test_important_priority_is_inspected_separately_from_value() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red !important; --tone: blue !IMPORTANT; background: white;' );
+	public function test_important_priority_syntax_variants( string $style, bool $important ) {
+		$processor = WP_HTML_Style_Attribute_Processor::create( $style );
 
 		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'red', $processor->get_value() );
-		$this->assertTrue( $processor->is_important() );
-
-		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'blue', $processor->get_value() );
-		$this->assertTrue( $processor->is_important() );
-
-		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'white', $processor->get_value() );
-		$this->assertFalse( $processor->is_important() );
+		$this->assertSame( $important, $processor->is_important() );
 	}
 
 	/**
@@ -120,7 +137,7 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_set_value_updates_current_declaration_without_collapsing_duplicates() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red !important; color: color(display-p3 1 0 0);' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red !important; color: color(display-p3 1 0 0);' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertTrue( $processor->set_value( 'green', false ) );
@@ -130,21 +147,160 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::set_value
-	 * @covers ::get_value
-	 * @covers ::is_important
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
 	 */
-	public function test_getters_reflect_current_declaration_after_set_value() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
+	public function test_declaration_values_allow_leading_and_trailing_comments_as_trivia() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
-		$this->assertTrue( $processor->set_value( 'green', true ) );
+		$this->assertTrue( $processor->set_value( '/* before */ green /* after */' ) );
+		$this->assertTrue( $processor->append_declaration( 'background', '/* before */ white /* after */' ) );
 
-		$this->assertSame( 'color', $processor->get_property_name() );
-		$this->assertSame( 'green', $processor->get_value() );
+		$this->assertSame( 'color: /* before */ green /* after */; background: /* before */ white /* after */;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::is_important
+	 */
+	public function test_set_value_preserves_sets_and_clears_importance() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red !important; background: white; border-color: black;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_value( 'green' ) );
 		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->set_value( 'blue', true ) );
+		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration( 'border-color' ) );
+		$this->assertTrue( $processor->set_value( 'currentColor', false ) );
+		$this->assertFalse( $processor->is_important() );
+
+		$this->assertSame(
+			'color: green !important; background: blue !important; border-color: currentColor;',
+			$processor->get_updated_style()
+		);
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::remove_declaration
+	 * @covers ::get_property_name
+	 * @covers ::is_important
+	 */
+	public function test_set_value_with_empty_string_removes_current_declaration() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_value( '' ) );
+
+		$this->assertNull( $processor->get_property_name() );
+		$this->assertNull( $processor->is_important() );
+		$this->assertFalse( $processor->set_value( 'green' ) );
+		$this->assertFalse( $processor->remove_declaration() );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::get_updated_style
+	 */
+	public function test_set_value_rejects_css_whitespace_only_values_without_removing_declaration() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertFalse( $processor->set_value( " \t\n\r\f" ) );
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+	}
+
+	/**
+	 * @covers ::set_important
+	 * @covers ::is_important
+	 * @covers ::get_updated_style
+	 */
+	public function test_set_important_sets_and_clears_priority() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; background: white ! /*x*/ important;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->set_important( false ) );
+		$this->assertFalse( $processor->is_important() );
+
+		$this->assertSame( 'color: red !important; background: white ;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_important
+	 * @covers ::get_updated_style
+	 */
+	public function test_set_important_can_repair_unclosed_eof_component_values() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'color: var(--x) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x /*c*/' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'color: var(--x /*c*/) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo' );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'background: url(foo) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x ' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'color: var(--x ) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x /*c*/ ' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'color: var(--x /*c*/ ) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo ' );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'background: url(foo ) !important', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo\\)' );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->set_important( true ) );
+		$this->assertTrue( $processor->is_important() );
+		$this->assertSame( 'background: url(foo\\)) !important', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_important
+	 */
+	public function test_set_important_returns_false_without_current_declaration() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
+
+		$this->assertFalse( $processor->set_important( true ) );
 	}
 
 	/**
@@ -152,7 +308,7 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_remove_declaration_removes_only_current_duplicate() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: blue; background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; color: blue; background: white;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
@@ -163,29 +319,10 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::remove_declaration
-	 * @covers ::get_property_name
-	 * @covers ::get_value
-	 */
-	public function test_getters_return_null_after_removing_current_declaration_until_cursor_advances() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
-
-		$this->assertTrue( $processor->next_declaration( 'color' ) );
-		$this->assertTrue( $processor->remove_declaration() );
-
-		$this->assertNull( $processor->get_property_name() );
-		$this->assertNull( $processor->get_value() );
-		$this->assertFalse( $processor->is_important() );
-
-		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'background', $processor->get_property_name() );
-	}
-
-	/**
-	 * @covers ::remove_declaration
 	 * @covers ::get_updated_style
 	 */
 	public function test_remove_declaration_removes_adjacent_duplicate_declarations() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: blue; background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; color: blue; background: white;' );
 
 		while ( $processor->next_declaration( 'color' ) ) {
 			$this->assertTrue( $processor->remove_declaration() );
@@ -196,22 +333,41 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::remove_declaration
+	 * @covers ::get_property_name
+	 * @covers ::is_important
+	 */
+	public function test_getters_return_null_after_removing_current_declaration_until_cursor_advances() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+
+		$this->assertNull( $processor->get_property_name() );
+		$this->assertNull( $processor->is_important() );
+		$this->assertFalse( $processor->remove_declaration() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+	}
+
+	/**
+	 * @covers ::remove_declaration
 	 * @covers ::get_updated_style
 	 */
 	public function test_remove_declaration_preserves_surrounding_comments() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '/*keep*/ color: red; background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( '/*keep*/ color: red; background: white;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertTrue( $processor->remove_declaration() );
 		$this->assertSame( '/*keep*/ background: white;', $processor->get_updated_style() );
 
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; /*keep*/ background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; /*keep*/ background: white;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertTrue( $processor->remove_declaration() );
 		$this->assertSame( '/*keep*/ background: white;', $processor->get_updated_style() );
 
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; /*keep*/ background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; /*keep*/ background: white;' );
 
 		$this->assertTrue( $processor->next_declaration( 'background' ) );
 		$this->assertTrue( $processor->remove_declaration() );
@@ -219,11 +375,26 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::remove_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_remove_declaration_with_invalid_fragments_preserves_remaining_structure() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red; invalid; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+		$this->assertSame( 'invalid; background: white;', $processor->get_updated_style() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+	}
+
+	/**
 	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
 	 */
 	public function test_append_declaration_adds_duplicate_declaration() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
 
 		$this->assertTrue( $processor->append_declaration( 'color', 'color(display-p3 1 0 0)', true ) );
 
@@ -235,7 +406,7 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_append_declaration_preserves_multiple_appends_in_order() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( '' );
 
 		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
 		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
@@ -248,17 +419,17 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_append_declaration_treats_comments_as_trivia_for_separators() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '/*keep*/' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( '/*keep*/' );
 
 		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
 		$this->assertSame( '/*keep*/ color: red;', $processor->get_updated_style() );
 
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;/*keep*/' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;/*keep*/' );
 
 		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
 		$this->assertSame( 'color: red;/*keep*/ background: white;', $processor->get_updated_style() );
 
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: var(--x;/*keep*/);' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x;/*keep*/);' );
 
 		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
 		$this->assertSame( 'color: var(--x;/*keep*/); background: white;', $processor->get_updated_style() );
@@ -268,26 +439,13 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
 	 */
-	public function test_append_declaration_rejects_unclosed_component_value_append_points() {
-		$style     = 'color: var(--x;/*keep*/';
-		$processor = new WP_HTML_Style_Attribute_Processor( $style );
+	public function test_append_declaration_lowercases_ordinary_properties_and_preserves_custom_properties() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( '' );
 
-		$this->assertFalse( $processor->append_declaration( 'background', 'white' ) );
-		$this->assertSame( $style, $processor->get_updated_style() );
-	}
+		$this->assertTrue( $processor->append_declaration( 'BackgroundColor', 'red' ) );
+		$this->assertTrue( $processor->append_declaration( '--Tone', 'warm' ) );
 
-	/**
-	 * @covers ::append_declaration
-	 * @covers ::next_declaration
-	 */
-	public function test_appended_declarations_can_be_inspected_by_the_cursor() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '' );
-
-		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
-
-		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'color', $processor->get_property_name() );
-		$this->assertSame( 'red', $processor->get_value() );
+		$this->assertSame( 'backgroundcolor: red; --Tone: warm;', $processor->get_updated_style() );
 	}
 
 	/**
@@ -295,20 +453,34 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::next_declaration
 	 * @covers ::get_property_name
 	 */
+	public function test_appended_declarations_can_be_inspected_by_the_cursor() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( '' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::next_declaration
+	 * @covers ::get_property_name
+	 * @covers ::set_value
+	 */
 	public function test_append_declaration_preserves_exhausted_cursor_until_it_advances() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertFalse( $processor->next_declaration() );
 		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
 
 		$this->assertNull( $processor->get_property_name() );
-		$this->assertNull( $processor->get_value() );
+		$this->assertNull( $processor->is_important() );
 		$this->assertFalse( $processor->set_value( 'green' ) );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'white', $processor->get_value() );
 		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
 	}
 
@@ -318,7 +490,7 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_append_declaration_after_removing_only_declaration() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;   ' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;   ' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertTrue( $processor->remove_declaration() );
@@ -328,16 +500,58 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_repairs_unclosed_eof_component_values() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x' );
+
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+		$this->assertSame( 'color: var(--x); background: white;', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'width: calc(1px + var(--gap' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+		$this->assertSame( 'width: calc(1px + var(--gap)); color: red;', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+		$this->assertSame( 'background: url(foo); color: red;', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo ' );
+
+		$this->assertTrue( $processor->append_declaration( 'border', '0' ) );
+		$this->assertSame( 'background: url(foo ); border: 0;', $processor->get_updated_style() );
+
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: url(foo\\)' );
+
+		$this->assertTrue( $processor->append_declaration( 'border', '0' ) );
+		$this->assertSame( 'background: url(foo\\)); border: 0;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_rejects_eof_repairs_that_cannot_be_precise() {
+		$style     = 'color: var(--x;/*keep';
+		$processor = WP_HTML_Style_Attribute_Processor::create( $style );
+
+		$this->assertFalse( $processor->append_declaration( 'background', 'white' ) );
+		$this->assertSame( $style, $processor->get_updated_style() );
+	}
+
+	/**
 	 * @covers ::next_declaration
 	 * @covers ::get_updated_style
 	 */
 	public function test_invalid_fragments_are_skipped_and_preserved() {
 		$style     = 'color red; @media (min-width: 1px) { color: green; } background: white;';
-		$processor = new WP_HTML_Style_Attribute_Processor( $style );
+		$processor = WP_HTML_Style_Attribute_Processor::create( $style );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'white', $processor->get_value() );
 		$this->assertFalse( $processor->next_declaration() );
 		$this->assertSame( $style, $processor->get_updated_style() );
 	}
@@ -346,24 +560,21 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::next_declaration
 	 */
 	public function test_stray_right_brace_consumes_bad_declaration_until_semicolon() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '} color: red; background: white;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( '} color: red; background: white;' );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'white', $processor->get_value() );
 		$this->assertFalse( $processor->next_declaration() );
 	}
 
 	/**
 	 * @covers ::next_declaration
-	 * @covers ::get_value
 	 */
 	public function test_values_can_contain_semicolons_inside_component_values() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'background: image-set(url("a;b.png") 1x); color: red;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'background: image-set(url("a;b.png") 1x); color: red;' );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'background', $processor->get_property_name() );
-		$this->assertSame( 'image-set(url("a;b.png") 1x)', $processor->get_value() );
 
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'color', $processor->get_property_name() );
@@ -375,7 +586,7 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::get_updated_style
 	 */
 	public function test_escaped_property_names_match_decoded_names_and_preserve_raw_spelling() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'c\\6f lor: red; --t\\6f ne: cool; --Tone: warm;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'c\\6f lor: red; --t\\6f ne: cool; --Tone: warm;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
 		$this->assertSame( 'color', $processor->get_property_name() );
@@ -384,50 +595,20 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 		$this->assertTrue( $processor->next_declaration( '--tone' ) );
 		$this->assertSame( '--tone', $processor->get_property_name() );
-		$this->assertSame( 'cool', $processor->get_value() );
+		$this->assertTrue( $processor->set_value( 'cold' ) );
+		$this->assertSame( 'c\\6f lor: green; --t\\6f ne: cold; --Tone: warm;', $processor->get_updated_style() );
 
 		$this->assertFalse( $processor->next_declaration( '--tone' ) );
 	}
 
 	/**
 	 * @covers ::is_important
-	 * @covers ::get_value
 	 */
 	public function test_important_inside_unclosed_function_is_not_declaration_priority() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: var(--x, red !important' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: var(--x, red !important' );
 
 		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( 'var(--x, red !important', $processor->get_value() );
 		$this->assertFalse( $processor->is_important() );
-	}
-
-	/**
-	 * @covers ::is_important
-	 * @covers ::get_value
-	 *
-	 * @dataProvider data_important_priority_syntax
-	 *
-	 * @param string $style     Style attribute value.
-	 * @param string $value     Expected declaration value.
-	 * @param bool   $important Expected importance.
-	 */
-	public function test_important_priority_syntax_variants( string $style, string $value, bool $important ) {
-		$processor = new WP_HTML_Style_Attribute_Processor( $style );
-
-		$this->assertTrue( $processor->next_declaration() );
-		$this->assertSame( $value, $processor->get_value() );
-		$this->assertSame( $important, $processor->is_important() );
-	}
-
-	/**
-	 * @covers ::append_declaration
-	 * @covers ::get_updated_style
-	 */
-	public function test_declaration_values_reject_top_level_semicolons() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
-
-		$this->assertFalse( $processor->append_declaration( 'background', 'blue; color: green' ) );
-		$this->assertSame( 'color: red;', $processor->get_updated_style() );
 	}
 
 	/**
@@ -435,12 +616,16 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
 	 */
-	public function test_declaration_values_reject_top_level_important_priority() {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+	public function test_declaration_values_reject_top_level_semicolons_and_important_priority() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
 
 		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertFalse( $processor->set_value( 'blue; color: green' ) );
 		$this->assertFalse( $processor->set_value( 'green ! important', false ) );
+		$this->assertFalse( $processor->set_value( 'green ! important foo', false ) );
+		$this->assertFalse( $processor->append_declaration( 'background', 'blue; color: green' ) );
 		$this->assertFalse( $processor->append_declaration( 'background', 'white !important' ) );
+		$this->assertFalse( $processor->append_declaration( 'background', 'white !important foo' ) );
 
 		$this->assertSame( 'color: red;', $processor->get_updated_style() );
 	}
@@ -448,26 +633,78 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	/**
 	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_rejects_empty_values() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
+
+		$this->assertFalse( $processor->append_declaration( 'background', '' ) );
+		$this->assertFalse( $processor->append_declaration( 'background', '/* comment */' ) );
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::get_updated_style
+	 */
+	public function test_set_value_rejects_comment_only_values_without_removing_declaration() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertFalse( $processor->set_value( '/* comment */' ) );
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::set_value
+	 * @covers ::get_updated_style
 	 *
 	 * @dataProvider data_malformed_declaration_values
 	 *
 	 * @param string $value Malformed CSS declaration value.
 	 */
 	public function test_declaration_values_reject_malformed_eof_tokens( string $value ) {
-		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+		$processor = WP_HTML_Style_Attribute_Processor::create( 'color: red;' );
 
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertFalse( $processor->set_value( $value ) );
 		$this->assertFalse( $processor->append_declaration( 'background', $value ) );
 		$this->assertSame( 'color: red;', $processor->get_updated_style() );
 	}
 
 	/**
+	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
 	 */
-	public function test_updated_style_can_be_set_on_html_tag_processor() {
+	public function test_property_names_reject_escaped_source_identifiers() {
+		$processor = WP_HTML_Style_Attribute_Processor::create( '' );
+
+		$this->assertFalse( $processor->append_declaration( 'color\\', 'red' ) );
+		$this->assertFalse( $processor->append_declaration( 'c\\6f lor', 'red' ) );
+		$this->assertSame( '', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function test_whitespace_constant_is_not_public_api() {
+		$reflection = new ReflectionClass( WP_HTML_Style_Attribute_Processor::class );
+
+		$this->assertFalse( $reflection->hasConstant( 'WHITESPACE' ) && $reflection->getReflectionConstant( 'WHITESPACE' )->isPublic() );
+	}
+
+	/**
+	 * @covers ::get_updated_style
+	 */
+	public function test_updated_style_can_be_set_on_html_tag_processor_after_string_check() {
 		$tags = new WP_HTML_Tag_Processor( '<div style="color: red; color: color(display-p3 1 0 0)">Text</div>' );
 		$this->assertTrue( $tags->next_tag( 'div' ) );
 
-		$styles = new WP_HTML_Style_Attribute_Processor( $tags->get_attribute( 'style' ) );
+		$style = $tags->get_attribute( 'style' );
+		$this->assertIsString( $style );
+
+		$styles = WP_HTML_Style_Attribute_Processor::create( $style );
 		$this->assertTrue( $styles->append_declaration( 'background', 'white' ) );
 		$this->assertTrue( $tags->set_attribute( 'style', $styles->get_updated_style() ) );
 
@@ -480,29 +717,27 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{string,string,string|null}>
+	 * @return array<string, array{mixed}>
 	 */
-	public static function data_html_style_attribute_values(): array {
+	public static function data_non_string_style_attribute_values(): array {
 		return array(
-			'missing style attribute' => array( '<div>Text</div>', '', null ),
-			'boolean style attribute' => array( '<div style>Text</div>', '', null ),
-			'empty style attribute'   => array( '<div style="">Text</div>', '', null ),
-			'valued style attribute'  => array( '<div style="color: red">Text</div>', 'color: red', 'color' ),
+			'missing style attribute' => array( null ),
+			'boolean style attribute' => array( true ),
 		);
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{string,string,bool}>
+	 * @return array<string, array{string,bool}>
 	 */
 	public static function data_important_priority_syntax(): array {
 		return array(
-			'no whitespace'         => array( 'color: red!important;', 'red', true ),
-			'whitespace after bang' => array( 'color: red ! important;', 'red', true ),
-			'comment after bang'    => array( 'color: red ! /*x*/ important;', 'red', true ),
-			'escaped important'     => array( 'color: red !\\69mportant;', 'red', true ),
-			'extra trailing token'  => array( 'color: red ! important foo;', 'red ! important foo', false ),
+			'no whitespace'         => array( 'color: red!important;', true ),
+			'whitespace after bang' => array( 'color: red ! important;', true ),
+			'comment after bang'    => array( 'color: red ! /*x*/ important;', true ),
+			'escaped important'     => array( 'color: red !\\69mportant;', true ),
+			'extra trailing token'  => array( 'color: red ! important foo;', false ),
 		);
 	}
 
@@ -522,16 +757,5 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 			'eof url apparent end escaped'    => array( 'url(foo\\)' ),
 			'eof escape'                      => array( 'red\\' ),
 		);
-	}
-
-	/**
-	 * @covers ::append_declaration
-	 * @covers ::get_updated_style
-	 */
-	public function test_property_names_reject_eof_escapes() {
-		$processor = new WP_HTML_Style_Attribute_Processor( '' );
-
-		$this->assertFalse( $processor->append_declaration( 'color\\', 'red' ) );
-		$this->assertSame( '', $processor->get_updated_style() );
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Style_Attribute_Processor functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since {WP_VERSION}
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Style_Attribute_Processor
+ */
+class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
+	/**
+	 * @covers ::next_declaration
+	 * @covers ::get_property_name
+	 * @covers ::get_value
+	 */
+	public function test_next_declaration_reads_properties_in_order_and_preserves_duplicates() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: color(display-p3 1 0 0); background: blue' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+		$this->assertSame( 'red', $processor->get_value() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+		$this->assertSame( 'color(display-p3 1 0 0)', $processor->get_value() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'blue', $processor->get_value() );
+
+		$this->assertFalse( $processor->next_declaration() );
+	}
+
+	/**
+	 * @covers ::next_declaration
+	 */
+	public function test_next_declaration_query_visits_matching_duplicate_properties() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white; COLOR: blue;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertSame( 'red', $processor->get_value() );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertSame( 'blue', $processor->get_value() );
+
+		$this->assertFalse( $processor->next_declaration( 'color' ) );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( '--Tone: warm; --tone: cool;' );
+
+		$this->assertTrue( $processor->next_declaration( '--tone' ) );
+		$this->assertSame( 'cool', $processor->get_value() );
+
+		$this->assertFalse( $processor->next_declaration( '--tone' ) );
+	}
+
+	/**
+	 * @covers ::is_important
+	 * @covers ::get_value
+	 */
+	public function test_important_priority_is_inspected_separately_from_value() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red !important; --tone: blue !IMPORTANT; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'red', $processor->get_value() );
+		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'blue', $processor->get_value() );
+		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'white', $processor->get_value() );
+		$this->assertFalse( $processor->is_important() );
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::get_updated_style
+	 */
+	public function test_set_value_updates_current_declaration_without_collapsing_duplicates() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red !important; color: color(display-p3 1 0 0);' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_value( 'green', false ) );
+
+		$this->assertSame( 'color: green; color: color(display-p3 1 0 0);', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::remove_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_remove_declaration_removes_only_current_duplicate() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: blue; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+
+		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::remove_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_remove_declaration_removes_adjacent_duplicate_declarations() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; color: blue; background: white;' );
+
+		while ( $processor->next_declaration( 'color' ) ) {
+			$this->assertTrue( $processor->remove_declaration() );
+		}
+
+		$this->assertSame( 'background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_adds_duplicate_declaration() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'color(display-p3 1 0 0)', true ) );
+
+		$this->assertSame( 'color: red; color: color(display-p3 1 0 0) !important;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_preserves_multiple_appends_in_order() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+
+		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::remove_declaration
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_after_removing_only_declaration() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;   ' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+
+		$this->assertSame( 'background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::next_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_invalid_fragments_are_skipped_and_preserved() {
+		$style     = 'color red; @media (min-width: 1px) { color: green; } background: white;';
+		$processor = new WP_HTML_Style_Attribute_Processor( $style );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'white', $processor->get_value() );
+		$this->assertFalse( $processor->next_declaration() );
+		$this->assertSame( $style, $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::next_declaration
+	 * @covers ::get_value
+	 */
+	public function test_values_can_contain_semicolons_inside_component_values() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'background: image-set(url("a;b.png") 1x); color: red;' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'image-set(url("a;b.png") 1x)', $processor->get_value() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+	}
+
+	/**
+	 * @covers ::is_important
+	 * @covers ::get_value
+	 */
+	public function test_important_inside_unclosed_function_is_not_declaration_priority() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: var(--x, red !important' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'var(--x, red !important', $processor->get_value() );
+		$this->assertFalse( $processor->is_important() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_declaration_values_reject_top_level_semicolons() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+
+		$this->assertFalse( $processor->append_declaration( 'background', 'blue; color: green' ) );
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::set_value
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_declaration_values_reject_top_level_important_priority() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertFalse( $processor->set_value( 'green ! important', false ) );
+		$this->assertFalse( $processor->append_declaration( 'background', 'white !important' ) );
+
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 *
+	 * @dataProvider data_malformed_declaration_values
+	 *
+	 * @param string $value Malformed CSS declaration value.
+	 */
+	public function test_declaration_values_reject_malformed_eof_tokens( string $value ) {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+
+		$this->assertFalse( $processor->append_declaration( 'background', $value ) );
+		$this->assertSame( 'color: red;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::get_updated_style
+	 */
+	public function test_updated_style_can_be_set_on_html_tag_processor() {
+		$tags = new WP_HTML_Tag_Processor( '<div style="color: red; color: color(display-p3 1 0 0)">Text</div>' );
+		$this->assertTrue( $tags->next_tag( 'div' ) );
+
+		$styles = new WP_HTML_Style_Attribute_Processor( $tags->get_attribute( 'style' ) );
+		$this->assertTrue( $styles->append_declaration( 'background', 'white' ) );
+		$this->assertTrue( $tags->set_attribute( 'style', $styles->get_updated_style() ) );
+
+		$this->assertSame(
+			'<div style="color: red; color: color(display-p3 1 0 0); background: white;">Text</div>',
+			$tags->get_updated_html()
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function data_malformed_declaration_values(): array {
+		return array(
+			'eof string'                      => array( '"unterminated' ),
+			'eof string escaped end'          => array( '"unterminated\\' ),
+			'eof string apparent end escaped' => array( '"unterminated\\"' ),
+			'eof comment'                     => array( '/*' ),
+			'eof url'                         => array( 'url(foo' ),
+			'eof url escaped end'             => array( 'url(foo\\' ),
+			'eof url apparent end escaped'    => array( 'url(foo\\)' ),
+			'eof escape'                      => array( 'red\\' ),
+		);
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_property_names_reject_eof_escapes() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '' );
+
+		$this->assertFalse( $processor->append_declaration( 'color\\', 'red' ) );
+		$this->assertSame( '', $processor->get_updated_style() );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -13,6 +13,33 @@
  */
 class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	/**
+	 * @covers ::__construct
+	 * @covers ::next_declaration
+	 * @covers ::get_updated_style
+	 *
+	 * @dataProvider data_html_style_attribute_values
+	 *
+	 * @param string      $html           HTML containing a first div.
+	 * @param string      $expected_style Expected normalized style input.
+	 * @param string|null $property_name  Expected first property name.
+	 */
+	public function test_constructor_accepts_html_tag_processor_style_attribute_values( string $html, string $expected_style, ?string $property_name ) {
+		$tags = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $tags->next_tag( 'div' ) );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( $tags->get_attribute( 'style' ) );
+
+		$this->assertSame( $expected_style, $processor->get_updated_style() );
+
+		if ( null === $property_name ) {
+			$this->assertFalse( $processor->next_declaration() );
+		} else {
+			$this->assertTrue( $processor->next_declaration() );
+			$this->assertSame( $property_name, $processor->get_property_name() );
+		}
+	}
+
+	/**
 	 * @covers ::next_declaration
 	 * @covers ::get_property_name
 	 * @covers ::get_value
@@ -175,6 +202,18 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::next_declaration
+	 */
+	public function test_stray_right_brace_consumes_bad_declaration_until_semicolon() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '} color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'white', $processor->get_value() );
+		$this->assertFalse( $processor->next_declaration() );
+	}
+
+	/**
+	 * @covers ::next_declaration
 	 * @covers ::get_value
 	 */
 	public function test_values_can_contain_semicolons_inside_component_values() {
@@ -189,6 +228,26 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::next_declaration
+	 * @covers ::set_value
+	 * @covers ::get_updated_style
+	 */
+	public function test_escaped_property_names_match_decoded_names_and_preserve_raw_spelling() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'c\\6f lor: red; --t\\6f ne: cool; --Tone: warm;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertSame( 'color', $processor->get_property_name() );
+		$this->assertTrue( $processor->set_value( 'green' ) );
+		$this->assertSame( 'c\\6f lor: green; --t\\6f ne: cool; --Tone: warm;', $processor->get_updated_style() );
+
+		$this->assertTrue( $processor->next_declaration( '--tone' ) );
+		$this->assertSame( '--tone', $processor->get_property_name() );
+		$this->assertSame( 'cool', $processor->get_value() );
+
+		$this->assertFalse( $processor->next_declaration( '--tone' ) );
+	}
+
+	/**
 	 * @covers ::is_important
 	 * @covers ::get_value
 	 */
@@ -198,6 +257,24 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 		$this->assertTrue( $processor->next_declaration() );
 		$this->assertSame( 'var(--x, red !important', $processor->get_value() );
 		$this->assertFalse( $processor->is_important() );
+	}
+
+	/**
+	 * @covers ::is_important
+	 * @covers ::get_value
+	 *
+	 * @dataProvider data_important_priority_syntax
+	 *
+	 * @param string $style     Style attribute value.
+	 * @param string $value     Expected declaration value.
+	 * @param bool   $important Expected importance.
+	 */
+	public function test_important_priority_syntax_variants( string $style, string $value, bool $important ) {
+		$processor = new WP_HTML_Style_Attribute_Processor( $style );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( $value, $processor->get_value() );
+		$this->assertSame( $important, $processor->is_important() );
 	}
 
 	/**
@@ -255,6 +332,35 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 		$this->assertSame(
 			'<div style="color: red; color: color(display-p3 1 0 0); background: white;">Text</div>',
 			$tags->get_updated_html()
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{string,string,string|null}>
+	 */
+	public static function data_html_style_attribute_values(): array {
+		return array(
+			'missing style attribute' => array( '<div>Text</div>', '', null ),
+			'boolean style attribute' => array( '<div style>Text</div>', '', null ),
+			'empty style attribute'   => array( '<div style="">Text</div>', '', null ),
+			'valued style attribute'  => array( '<div style="color: red">Text</div>', 'color: red', 'color' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{string,string,bool}>
+	 */
+	public static function data_important_priority_syntax(): array {
+		return array(
+			'no whitespace'         => array( 'color: red!important;', 'red', true ),
+			'whitespace after bang' => array( 'color: red ! important;', 'red', true ),
+			'comment after bang'    => array( 'color: red ! /*x*/ important;', 'red', true ),
+			'escaped important'     => array( 'color: red !\\69mportant;', 'red', true ),
+			'extra trailing token'  => array( 'color: red ! important foo;', 'red ! important foo', false ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -85,6 +85,17 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::next_declaration
+	 */
+	public function test_next_declaration_accepts_named_property_name_argument() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( property_name: 'background' ) );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'white', $processor->get_value() );
+	}
+
+	/**
 	 * @covers ::is_important
 	 * @covers ::get_value
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -184,6 +184,30 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::remove_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_remove_declaration_preserves_surrounding_comments() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '/*keep*/ color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+		$this->assertSame( '/*keep*/ background: white;', $processor->get_updated_style() );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; /*keep*/ background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+		$this->assertSame( '/*keep*/ background: white;', $processor->get_updated_style() );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; /*keep*/ background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'background' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+		$this->assertSame( 'color: red; /*keep*/', $processor->get_updated_style() );
+	}
+
+	/**
 	 * @covers ::append_declaration
 	 * @covers ::get_updated_style
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -118,6 +118,25 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::set_value
+	 * @covers ::get_value
+	 * @covers ::is_important
+	 */
+	public function test_getters_reflect_current_declaration_after_set_value() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->set_value( 'green', true ) );
+
+		$this->assertSame( 'color', $processor->get_property_name() );
+		$this->assertSame( 'green', $processor->get_value() );
+		$this->assertTrue( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+	}
+
+	/**
 	 * @covers ::remove_declaration
 	 * @covers ::get_updated_style
 	 */
@@ -129,6 +148,25 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 		$this->assertTrue( $processor->remove_declaration() );
 
 		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::remove_declaration
+	 * @covers ::get_property_name
+	 * @covers ::get_value
+	 */
+	public function test_getters_return_null_after_removing_current_declaration_until_cursor_advances() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red; background: white;' );
+
+		$this->assertTrue( $processor->next_declaration( 'color' ) );
+		$this->assertTrue( $processor->remove_declaration() );
+
+		$this->assertNull( $processor->get_property_name() );
+		$this->assertNull( $processor->get_value() );
+		$this->assertFalse( $processor->is_important() );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
 	}
 
 	/**
@@ -167,6 +205,42 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
 		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
 
+		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::next_declaration
+	 */
+	public function test_appended_declarations_can_be_inspected_by_the_cursor() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'color', $processor->get_property_name() );
+		$this->assertSame( 'red', $processor->get_value() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::next_declaration
+	 * @covers ::get_property_name
+	 */
+	public function test_append_declaration_preserves_exhausted_cursor_until_it_advances() {
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;' );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertFalse( $processor->next_declaration() );
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+
+		$this->assertNull( $processor->get_property_name() );
+		$this->assertNull( $processor->get_value() );
+		$this->assertFalse( $processor->set_value( 'green' ) );
+
+		$this->assertTrue( $processor->next_declaration() );
+		$this->assertSame( 'background', $processor->get_property_name() );
+		$this->assertSame( 'white', $processor->get_value() );
 		$this->assertSame( 'color: red; background: white;', $processor->get_updated_style() );
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlStyleAttributeProcessor.php
@@ -210,6 +210,39 @@ class Tests_HtmlApi_WpHtmlStyleAttributeProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_treats_comments_as_trivia_for_separators() {
+		$processor = new WP_HTML_Style_Attribute_Processor( '/*keep*/' );
+
+		$this->assertTrue( $processor->append_declaration( 'color', 'red' ) );
+		$this->assertSame( '/*keep*/ color: red;', $processor->get_updated_style() );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: red;/*keep*/' );
+
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+		$this->assertSame( 'color: red;/*keep*/ background: white;', $processor->get_updated_style() );
+
+		$processor = new WP_HTML_Style_Attribute_Processor( 'color: var(--x;/*keep*/);' );
+
+		$this->assertTrue( $processor->append_declaration( 'background', 'white' ) );
+		$this->assertSame( 'color: var(--x;/*keep*/); background: white;', $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
+	 * @covers ::get_updated_style
+	 */
+	public function test_append_declaration_rejects_unclosed_component_value_append_points() {
+		$style     = 'color: var(--x;/*keep*/';
+		$processor = new WP_HTML_Style_Attribute_Processor( $style );
+
+		$this->assertFalse( $processor->append_declaration( 'background', 'white' ) );
+		$this->assertSame( $style, $processor->get_updated_style() );
+	}
+
+	/**
+	 * @covers ::append_declaration
 	 * @covers ::next_declaration
 	 */
 	public function test_appended_declarations_can_be_inspected_by_the_cursor() {

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1545,6 +1545,62 @@ EOF;
 				'css'      => 'text-anchor: middle',
 				'expected' => 'text-anchor: middle',
 			),
+			// Token-based parsing: a semicolon inside a quoted
+			// string does not split the declaration.
+			array(
+				'css'      => 'font-family: "a;b"',
+				'expected' => 'font-family: "a;b"',
+			),
+			// A semicolon inside url() does not split the declaration.
+			array(
+				'css'      => 'background-image: url("image;1.jpg")',
+				'expected' => 'background-image: url("image;1.jpg")',
+			),
+			// A bad-protocol url nested inside an allowed function is rejected.
+			array(
+				'css'      => 'width: calc(url(javascript:document.title))',
+				'expected' => '',
+			),
+			// A quoted bad-protocol url nested inside an allowed function is rejected.
+			array(
+				'css'      => 'width: calc(url("javascript:alert(1)"))',
+				'expected' => '',
+			),
+			// A valid nested url is allowed on a url-allowed property.
+			array(
+				'css'      => 'background-image: linear-gradient(url(foo.jpg), red)',
+				'expected' => 'background-image: linear-gradient(url(foo.jpg), red)',
+			),
+			// An unclosed function swallows the remainder of the input.
+			array(
+				'css'      => 'width: calc(3em; height: 10px',
+				'expected' => '',
+			),
+			// url() with only whitespace inside is rejected.
+			array(
+				'css'      => 'background-image: url( )',
+				'expected' => '',
+			),
+			// A string left unclosed at the end of input is rejected.
+			array(
+				'css'      => 'color: "red',
+				'expected' => '',
+			),
+			// An opening curly brace is rejected.
+			array(
+				'css'      => 'width: 2px{',
+				'expected' => '',
+			),
+			// url() is matched ASCII case-insensitively, as CSS specifies.
+			array(
+				'css'      => 'background-image: URL(foo.jpg)',
+				'expected' => 'background-image: URL(foo.jpg)',
+			),
+			// A comment in a value is rejected.
+			array(
+				'css'      => 'color: red /* comment */',
+				'expected' => '',
+			),
 		);
 	}
 
@@ -1920,6 +1976,41 @@ EOF;
 				'expected' => 'color: rgb( 100, 100, 100, .4 )',
 			),
 		);
+	}
+
+	/**
+	 * The `safecss_filter_attr_allow_css` filter receives each declaration's
+	 * authored source text as its second argument.
+	 *
+	 * @covers ::safecss_filter_attr
+	 */
+	public function test_safecss_filter_attr_filter_receives_declaration_source() {
+		$received = array();
+		$filter   = static function ( $allow_css, $css_test_string ) use ( &$received ) {
+			$received[] = $css_test_string;
+			return $allow_css;
+		};
+
+		add_filter( 'safecss_filter_attr_allow_css', $filter, 10, 2 );
+		safecss_filter_attr( 'color: rgb(1,2,3); width: 10px' );
+		remove_filter( 'safecss_filter_attr_allow_css', $filter );
+
+		$this->assertSame( array( 'color: rgb(1,2,3)', 'width: 10px' ), $received );
+	}
+
+	/**
+	 * Hard rejections (unknown properties, bad-protocol urls) are dropped
+	 * before the `safecss_filter_attr_allow_css` filter runs and cannot be
+	 * rescued by it.
+	 *
+	 * @covers ::safecss_filter_attr
+	 */
+	public function test_safecss_filter_attr_hard_rejections_bypass_filter() {
+		add_filter( 'safecss_filter_attr_allow_css', '__return_true' );
+		$actual = safecss_filter_attr( 'background-image: url("javascript:alert(1)"); foo: bar' );
+		remove_filter( 'safecss_filter_attr_allow_css', '__return_true' );
+
+		$this->assertSame( '', $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1601,6 +1601,41 @@ EOF;
 				'css'      => 'color: red /* comment */',
 				'expected' => '',
 			),
+			// A malformed url() with a bad-protocol string is rejected.
+			array(
+				'css'      => 'background-image: url("javascript:alert(1)" foo)',
+				'expected' => '',
+			),
+			// A bad-url token with a bad-protocol payload is rejected.
+			array(
+				'css'      => "background-image: url(javascript:a'b)",
+				'expected' => '',
+			),
+			// An unquoted url containing whitespace is rejected.
+			array(
+				'css'      => 'background-image: url(a b)',
+				'expected' => '',
+			),
+			// Nesting two levels deep inside a gradient is rejected.
+			array(
+				'css'      => 'background-image: linear-gradient(rgb(calc(1)))',
+				'expected' => '',
+			),
+			// Function name matching is case-sensitive.
+			array(
+				'css'      => 'width: CALC(2em + 3px)',
+				'expected' => '',
+			),
+			// A bad-protocol bad-url nested inside an allowed function is rejected.
+			array(
+				'css'      => "background: calc(url(javascript:a'b))",
+				'expected' => '',
+			),
+			// A comment-separated bad-protocol url payload is rejected.
+			array(
+				'css'      => 'background-image: url(/**/"javascript:alert(1)")',
+				'expected' => '',
+			),
 		);
 	}
 
@@ -1974,6 +2009,26 @@ EOF;
 			array(
 				'css'      => 'color: rgb( 100, 100, 100, .4 )',
 				'expected' => 'color: rgb( 100, 100, 100, .4 )',
+			),
+			// Malformed url() constructs with safe payloads can be rescued by the filter.
+			array(
+				'css'      => 'background-image: url("foo.jpg" bar)',
+				'expected' => 'background-image: url("foo.jpg" bar)',
+			),
+			// A malformed url() with a bad-protocol string cannot be rescued.
+			array(
+				'css'      => 'background-image: url("javascript:alert(1)" foo)',
+				'expected' => '',
+			),
+			// A bad-url token with a bad-protocol payload cannot be rescued.
+			array(
+				'css'      => "background-image: url(javascript:a'b)",
+				'expected' => '',
+			),
+			// A comment-separated bad-protocol url payload cannot be rescued.
+			array(
+				'css'      => 'background-image: url(/**/"javascript:alert(1)")',
+				'expected' => '',
 			),
 		);
 	}


### PR DESCRIPTION
## What

Re-implements `safecss_filter_attr()` (in `src/wp-includes/kses.php`) on top of `WP_CSS_Token_Processor`, replacing the `explode( ';' )` declaration splitting and regex-based validation with CSS Syntax Level 3 tokenization.

For background on the CSS Tokenizer itself, see https://github.com/sirreal/wordpress-develop/pull/78. This branch stacks on top of that work plus the `WP_HTML_Style_Attribute_Processor` contract.

## Design

The full design is in [`docs/safecss-filter-attr-token-processor-spec.md`](https://github.com/ockham/wordpress-develop/blob/css-token-style-attr-processor/docs/safecss-filter-attr-token-processor-spec.md). Highlights:

- Declarations are discovered at top-level semicolons via a single tokenizer pass, so `;` inside strings and `url()` no longer splits declarations (resolves the long-standing `@todo`).
- The character-denylist regex (`%[\\\(&=}]|/\*%`) and the url/gradient/function-stripping regexes are replaced by token-based validation.
- Every `url()` construct — at any nesting depth — is protocol-checked with `wp_kses_bad_protocol()`, closing the `calc(url(javascript:…))` loophole. This includes payloads inside *structurally malformed* constructs (bad-url tokens, malformed quoted `url()` forms): an identifiable bad-protocol payload is always a hard rejection, while structurally-malformed-but-clean shapes remain soft (filter-rescuable) rejections.
- The `safecss_filter_attr_allow_css` filter is retained: `$allow_css` now comes from token validation; soft rejections remain rescuable, hard rejections (unknown property, bad-protocol url) still bypass the filter as today. Note: the filter's second argument is now the declaration's authored source text rather than the old function-stripped test string.
- Output remains the trimmed authored source of accepted declarations joined with `;`. All pre-existing kses PHPUnit tests pass unchanged (382 tests in `tests/phpunit/tests/kses.php` incl. the new ones). Deliberate divergences (all toward strictness, or CSS-correct loosenings like case-insensitive `URL(…)`) are enumerated in the spec.

## Status

- [x] Spec document
- [x] Implementation
- [x] New test cases (see spec's Test Requirements section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)